### PR TITLE
Namespaces explores

### DIFF
--- a/generator/explores.py
+++ b/generator/explores.py
@@ -1,0 +1,34 @@
+"""All possible generated explores."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterator, List
+
+
+@dataclass
+class Explore:
+    """A generic explore."""
+
+    name: str
+    type: str
+    views: Dict[str, str]
+
+    def to_dict(self) -> dict:
+        """Explore instance represented as a dict."""
+        return {self.name: {"type": self.type, "views": self.views}}
+
+
+@dataclass
+class PingExplore(Explore):
+    """A Ping Table explore."""
+
+    @staticmethod
+    def from_views(views: Dict[str, List[Dict[str, str]]]) -> Iterator[PingExplore]:
+        """Generate all possible PingExplores from the views."""
+        for view, channel_infos in views.items():
+            is_ping_tbl = all((c.get("is_ping_table", False) for c in channel_infos))
+            if is_ping_tbl:
+                yield PingExplore(view, "ping_explore", {"base_view": view})
+
+
+explore_types = [PingExplore]

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -10,9 +10,12 @@ from io import BytesIO
 from itertools import groupby
 from operator import itemgetter
 from pathlib import Path
+from typing import Dict, List
 
 import click
 import yaml
+
+from .explores import explore_types
 
 PROBE_INFO_BASE_URI = "https://probeinfo.telemetry.mozilla.org"
 
@@ -40,6 +43,15 @@ def _get_views(uri):
                         ref.split(".") for ref in references["view.sql"]
                     ]
     return views
+
+
+def _get_explores(views: Dict[str, List[Dict[str, str]]]) -> dict:
+    explores = {}
+    for klass in explore_types:
+        for explore in klass.from_views(views):
+            explores.update(explore.to_dict())
+
+    return explores
 
 
 @click.command(help=__doc__)
@@ -100,6 +112,7 @@ def namespaces(custom_namespaces, generated_sql_uri, app_listings_uri):
         namespaces[app_name] = {
             "canonical_app_name": canonical_app_name,
             "views": dict(views),
+            "explores": _get_explores(dict(views)),
         }
 
     if custom_namespaces is not None:

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -126,6 +126,11 @@ def test_namespaces(runner, custom_namespaces, generated_sql_uri, app_listings_u
                       table: mozdata.custom.baseline
                 glean-app:
                   canonical_app_name: Glean App
+                  explores:
+                    baseline:
+                      type: ping_explore
+                      views:
+                        base_view: baseline
                   views:
                     baseline:
                     - channel: release


### PR DESCRIPTION
This does nothing yet except expose a new section of `namespaces.yaml` called `explores`. Eventually we'll do a few things:

1. Just use this section to generate LookML, and not need to decipher which explores we need from the views
2. Generate LookML within the explore classes (extensibly, using the dimensions)