### PR TITLE
Return instances of Views rather than dicts

### DIFF
--- a/generator/explores.py
+++ b/generator/explores.py
@@ -43,4 +43,25 @@ class PingExplore(Explore):
         return PingExplore(name, "ping_explore", defn["views"])
 
 
-explore_types = {"ping_explore": PingExplore}
+class GrowthAccountingExplore(Explore):
+    """A Growth Accounting Explore, from Baseline Clients Last Seen."""
+
+    @staticmethod
+    def from_views(views: Dict[str, List[Dict[str, str]]]) -> Iterator[PingExplore]:
+        """
+        If possible, generate a Growth Accounting explore for this namespace.
+
+        Growth accounting explores are only created for growth_accounting views.
+        """
+        if "growth_accounting" in views.keys():
+            yield GrowthAccountingExplore(
+                "growth_accounting",
+                "growth_accounting_explore",
+                {"base_view": "growth_accounting"},
+            )
+
+
+explore_types = {
+    "ping_explore": PingExplore,
+    "growth_accounting_explore": GrowthAccountingExplore,
+}

--- a/generator/explores.py
+++ b/generator/explores.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Iterator, List
 
+from .views import PingView, View
+
 
 @dataclass
 class Explore:
@@ -16,6 +18,15 @@ class Explore:
     def to_dict(self) -> dict:
         """Explore instance represented as a dict."""
         return {self.name: {"type": self.type, "views": self.views}}
+
+    def to_lookml(self) -> dict:
+        """Generate LookML for this explore."""
+        raise NotImplementedError("Only implemented in subclasses")
+
+    @staticmethod
+    def from_dict(name: str, defn: dict) -> Explore:
+        """Get an instance of an explore from a namespace definition."""
+        raise NotImplementedError("Only implemented in subclasses")
 
 
 @dataclass
@@ -30,12 +41,11 @@ class PingExplore(Explore):
         }
 
     @staticmethod
-    def from_views(views: Dict[str, List[Dict[str, str]]]) -> Iterator[PingExplore]:
+    def from_views(views: List[View]) -> Iterator[PingExplore]:
         """Generate all possible PingExplores from the views."""
-        for view, channel_infos in views.items():
-            is_ping_tbl = all((c.get("is_ping_table", False) for c in channel_infos))
-            if is_ping_tbl:
-                yield PingExplore(view, "ping_explore", {"base_view": view})
+        for view in views:
+            if view.view_type == PingView.type:
+                yield PingExplore(view.name, "ping_explore", {"base_view": view.name})
 
     @staticmethod
     def from_dict(name: str, defn: dict) -> PingExplore:
@@ -47,18 +57,19 @@ class GrowthAccountingExplore(Explore):
     """A Growth Accounting Explore, from Baseline Clients Last Seen."""
 
     @staticmethod
-    def from_views(views: Dict[str, List[Dict[str, str]]]) -> Iterator[PingExplore]:
+    def from_views(views: List[View]) -> Iterator[GrowthAccountingExplore]:
         """
         If possible, generate a Growth Accounting explore for this namespace.
 
         Growth accounting explores are only created for growth_accounting views.
         """
-        if "growth_accounting" in views.keys():
-            yield GrowthAccountingExplore(
-                "growth_accounting",
-                "growth_accounting_explore",
-                {"base_view": "growth_accounting"},
-            )
+        for view in views:
+            if view.name == "growth_accounting":
+                yield GrowthAccountingExplore(
+                    "growth_accounting",
+                    "growth_accounting_explore",
+                    {"base_view": "growth_accounting"},
+                )
 
 
 explore_types = {

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -144,7 +144,8 @@ def _generate_measures(dimensions: List[dict], table: str) -> List[Dict[str, str
 def _generate_views(
     client, out_dir: Path, views: Dict[str, List[Dict[str, str]]]
 ) -> Iterable[Path]:
-    for name, tables in views.items():
+    for name, defn in views.items():
+        tables = defn["tables"]
         view: Dict[str, Any] = {"name": name}
         # use schema for the table where channel=="release" or the first one
         table = next(
@@ -184,6 +185,9 @@ def _generate_explores(
     client, out_dir: Path, namespace: str, explores: dict
 ) -> Iterable[Path]:
     for explore_name, defn in explores.items():
+        if defn["type"] != "ping_explore":
+            continue
+
         explore = explore_types[defn["type"]].from_dict(explore_name, defn)
         explore_lookml = explore.to_lookml()
         file_lookml = {

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -3,7 +3,7 @@ import logging
 import re
 from itertools import filterfalse
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple, TypedDict
 
 import click
 import lkml
@@ -36,6 +36,13 @@ MAP_LAYER_NAMES = {
     ("country",): "countries",
     ("metadata", "geo", "country"): "countries",
 }
+
+
+class ViewDict(TypedDict):
+    """Represent a view definition."""
+
+    type: str
+    tables: List[Dict[str, str]]
 
 
 def _get_dimension(path: Tuple[str, ...], field_type: str, mode: str) -> Dict[str, Any]:
@@ -142,7 +149,7 @@ def _generate_measures(dimensions: List[dict], table: str) -> List[Dict[str, str
 
 
 def _generate_views(
-    client, out_dir: Path, views: Dict[str, List[Dict[str, str]]]
+    client, out_dir: Path, views: Dict[str, ViewDict]
 ) -> Iterable[Path]:
     for name, defn in views.items():
         tables = defn["tables"]

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -146,7 +146,6 @@ def _get_explores(views: List[View]) -> dict:
 def namespaces(custom_namespaces, generated_sql_uri, app_listings_uri):
     """Generate namespaces.yaml."""
     warnings.filterwarnings("ignore", module="google.auth._default")
-
     glean_apps = _get_glean_apps(app_listings_uri)
     db_views = _get_db_views(generated_sql_uri)
 
@@ -154,7 +153,7 @@ def namespaces(custom_namespaces, generated_sql_uri, app_listings_uri):
     for app in glean_apps:
         looker_views = _get_looker_views(app, db_views)
         explores = _get_explores(looker_views)
-        views_as_dict = {view.name: view.tables for view in looker_views}
+        views_as_dict = {view.name: view.as_dict() for view in looker_views}
 
         namespaces[app["app_name"]] = {
             "canonical_app_name": app["canonical_app_name"],

--- a/generator/views.py
+++ b/generator/views.py
@@ -117,6 +117,6 @@ class GrowthAccountingView(View):
 
 
 view_types = {
-    "ping_view": PingView,
-    "growth_accounting": GrowthAccountingView,
+    PingView.type: PingView,
+    GrowthAccountingView.type: GrowthAccountingView,
 }

--- a/generator/views.py
+++ b/generator/views.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Dict, Union
+from typing import Dict, Iterator, List
 
 OMIT_VIEWS = {"deletion_request"}
 
@@ -10,49 +10,103 @@ OMIT_VIEWS = {"deletion_request"}
 class View(object):
     """A generic Looker View."""
 
+    name: str
+    view_type: str
+    tables: List[Dict[str, str]]
+
+    def __init__(self, name: str, view_type: str, tables: List[Dict[str, str]]):
+        """Create an instance of a view."""
+        self.tables = tables
+        self.name = name
+        self.view_type = view_type
+
     @classmethod
-    def from_db_views(klass, variants: dict, db_views: dict) -> dict:
-        """Get Looker views from db views and app variants."""
-        raise NotImplementedError()
+    def from_db_views(
+        klass, app: str, channels: List[Dict[str, str]], db_views: dict
+    ) -> Iterator[View]:
+        """Get Looker views from app."""
+        raise NotImplementedError("Only implemented in subclass.")
+
+    def get_type(self) -> str:
+        """Get the type of this view."""
+        return self.view_type
+
+    def __str__(self):
+        """Stringify."""
+        return f"name: {self.name}, type: {self.type}, table: {self.tables}"
+
+    def __eq__(self, other) -> bool:
+        """Check for equality with other View."""
+
+        def comparable_dict(d):
+            return {tuple(sorted(t.items())) for t in self.tables}
+
+        if isinstance(other, View):
+            return (
+                self.name == other.name
+                and self.view_type == other.view_type
+                and comparable_dict(self.tables) == comparable_dict(other.tables)
+            )
+        return False
 
 
 class PingView(View):
     """A view on a ping table."""
 
+    type: str = "ping_view"
+
+    def __init__(self, name: str, tables: List[Dict[str, str]]):
+        """Create instance of a PingView."""
+        super().__init__(name, PingView.type, tables)
+
     @classmethod
-    def from_db_views(klass, variants: dict, db_views: dict):
-        """Get Looker views from db views and app variants."""
+    def from_db_views(
+        klass, app: str, channels: List[Dict[str, str]], db_views: dict
+    ) -> Iterator[PingView]:
+        """Get Looker views for a namespace."""
         views = defaultdict(list)
-        for app in variants:
-            if app.get("deprecated"):
-                continue
-            is_release = app.get("app_channel") == "release"
-            dataset_id = app["bq_dataset_family"]
-            for view_id, references in db_views[dataset_id].items():
+        for channel in channels:
+            dataset = channel["dataset"]
+
+            for view_id, references in db_views[dataset].items():
                 if view_id in OMIT_VIEWS:
                     continue
-                table: Dict[str, Union[str, bool]] = {
-                    "table": f"mozdata.{dataset_id}.{view_id}"
-                }
-                if "app_channel" in app:
-                    table["channel"] = app["app_channel"]
-                if len(references) == 1 and references[0][-2] == f"{dataset_id}_stable":
-                    # view references a single table in the stable dataset
-                    table["is_ping_table"] = True
-                elif not is_release:
-                    continue  # ignore non-ping tables from non-release datasets
+
+                table: Dict[str, str] = {"table": f"mozdata.{dataset}.{view_id}"}
+
+                if channel.get("channel"):
+                    table["channel"] = channel["channel"]
+                if len(references) != 1 or references[0][-2] != f"{dataset}_stable":
+                    continue  # This view is only for ping tables
+
                 views[view_id].append(table)
 
-        return views
+        for view_id, tables in views.items():
+            yield PingView(view_id, tables)
 
 
 class GrowthAccountingView(View):
     """A view for growth accounting measures."""
 
+    type: str = "growth_accounting_view"
+
+    def __init__(self, tables: List[Dict[str, str]]):
+        """Get an instance of a GrowthAccountingView."""
+        super().__init__("growth_accounting", GrowthAccountingView.type, tables)
+
     @classmethod
-    def from_db_views(klass, variants: dict, db_views: dict):
+    def from_db_views(
+        klass, app: str, channels: List[Dict[str, str]], db_views: dict
+    ) -> Iterator[GrowthAccountingView]:
         """Get Growth Accounting Views from db views and app variants."""
-        return {}
+        dataset = next(
+            (channel for channel in channels if channel.get("channel") == "release"),
+            channels[0],
+        )["dataset"]
+
+        for view_id, references in db_views[dataset].items():
+            if view_id == "baseline_clients_last_seen":
+                yield GrowthAccountingView([{"table": f"mozdata.{dataset}.{view_id}"}])
 
 
 view_types = {

--- a/generator/views.py
+++ b/generator/views.py
@@ -81,7 +81,7 @@ class PingView(View):
 
                 table: Dict[str, str] = {"table": f"mozdata.{dataset}.{view_id}"}
 
-                if channel.get("channel"):
+                if "channel" in channel:
                     table["channel"] = channel["channel"]
                 if len(references) != 1 or references[0][-2] != f"{dataset}_stable":
                     continue  # This view is only for ping tables

--- a/generator/views.py
+++ b/generator/views.py
@@ -31,6 +31,13 @@ class View(object):
         """Get the type of this view."""
         return self.view_type
 
+    def as_dict(self) -> dict:
+        """Get this view as a dictionary."""
+        return {
+            "type": self.view_type,
+            "tables": self.tables,
+        }
+
     def __str__(self):
         """Stringify."""
         return f"name: {self.name}, type: {self.type}, table: {self.tables}"

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -114,16 +114,20 @@ def test_lookml(runner, tmp_path):
               canonical_app_name: Custom
               views:
                 baseline:
-                - channel: release
-                  table: mozdata.custom.baseline
+                  type: ping_view
+                  tables:
+                  - channel: release
+                    table: mozdata.custom.baseline
             glean-app:
               canonical_app_name: Glean App
               views:
                 baseline:
-                - channel: release
-                  table: mozdata.glean_app.baseline
-                - channel: beta
-                  table: mozdata.glean_app_beta.baseline
+                  type: ping_view
+                  tables:
+                  - channel: release
+                    table: mozdata.glean_app.baseline
+                  - channel: beta
+                    table: mozdata.glean_app_beta.baseline
               explores:
                 baseline:
                   type: ping_explore
@@ -361,8 +365,10 @@ def test_duplicate_dimension(runner, tmp_path):
               canonical_app_name: Custom
               views:
                 baseline:
-                - channel: release
-                  table: mozdata.fail.duplicate_dimension
+                  type: ping_explore
+                  tables:
+                  - channel: release
+                    table: mozdata.fail.duplicate_dimension
             """
         )
     )
@@ -391,8 +397,10 @@ def test_duplicate_measure(runner, tmp_path):
               canonical_app_name: Custom
               views:
                 baseline:
-                - channel: release
-                  table: mozdata.fail.duplicate_measure
+                  type: ping_explore
+                  tables:
+                  - channel: release
+                    table: mozdata.fail.duplicate_measure
             """
         )
     )

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -33,8 +33,10 @@ def custom_namespaces(tmp_path):
               canonical_app_name: Custom
               views:
                 baseline:
-                - channel: release
-                  table: mozdata.custom.baseline
+                  type: ping_view
+                  tables:
+                  - channel: release
+                    table: mozdata.custom.baseline
             """
         ).lstrip()
     )
@@ -163,8 +165,10 @@ def test_namespaces_full(
                   canonical_app_name: Custom
                   views:
                     baseline:
-                    - channel: release
-                      table: mozdata.custom.baseline
+                      tables:
+                      - channel: release
+                        table: mozdata.custom.baseline
+                      type: ping_view
                 glean-app:
                   canonical_app_name: Glean App
                   explores:
@@ -178,12 +182,16 @@ def test_namespaces_full(
                         base_view: growth_accounting
                   views:
                     baseline:
-                    - channel: release
-                      table: mozdata.glean_app.baseline
-                    - channel: beta
-                      table: mozdata.glean_app_beta.baseline
+                      tables:
+                      - channel: release
+                        table: mozdata.glean_app.baseline
+                      - channel: beta
+                        table: mozdata.glean_app_beta.baseline
+                      type: ping_view
                     growth_accounting:
-                    - table: mozdata.glean_app.baseline_clients_last_seen
+                      tables:
+                      - table: mozdata.glean_app.baseline_clients_last_seen
+                      type: growth_accounting_view
                 """
             ).lstrip()
             == Path("namespaces.yaml").read_text()

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -9,7 +9,13 @@ from textwrap import dedent
 import pytest
 from click.testing import CliRunner
 
-from generator.namespaces import namespaces
+from generator.namespaces import (
+    _get_db_views,
+    _get_glean_apps,
+    _get_looker_views,
+    namespaces,
+)
+from generator.views import GrowthAccountingView, PingView
 
 
 @pytest.fixture
@@ -39,32 +45,43 @@ def custom_namespaces(tmp_path):
 def generated_sql_uri(tmp_path):
     dest = tmp_path / "bigquery_etl.tar.gz"
     with tarfile.open(dest, "w:gz") as tar:
+
+        def add_to_tar(path, content):
+            content = dedent(content).lstrip()
+            info = tarfile.TarInfo(path)
+            info.size = len(content)
+            tar.addfile(info, BytesIO(content.encode()))
+
         for dataset in ("glean_app", "glean_app_beta"):
-            content = dedent(
-                f"""
+            content = f"""
                 references:
                   view.sql:
                   - moz-fx-data-shared-prod.{dataset}_derived.baseline_clients_daily_v1
                 """
-            ).lstrip()
-            info = tarfile.TarInfo(
+            path = (
                 f"sql/moz-fx-data-shared-prod/{dataset}/"
                 "baseline_clients_daily/metadata.yaml"
             )
-            info.size = len(content)
-            tar.addfile(info, BytesIO(content.encode()))
-            content = dedent(
-                f"""
+            add_to_tar(path, content)
+
+            content = f"""
                 references:
                   view.sql:
                   - moz-fx-data-shared-prod.{dataset}_stable.baseline_v1
                 """
-            ).lstrip()
-            info = tarfile.TarInfo(
-                f"sql/moz-fx-data-shared-prod/{dataset}/baseline/metadata.yaml"
+            path = f"sql/moz-fx-data-shared-prod/{dataset}/baseline/metadata.yaml"
+            add_to_tar(path, content)
+
+            content = f"""
+                references:
+                  view.sql:
+                  - moz-fx-data-shared-prod.{dataset}_derived.baseline_clients_last_seen_v1
+                """
+            path = (
+                f"sql/moz-fx-data-shared-prod/{dataset}/"
+                "baseline_clients_last_seen/metadata.yaml"
             )
-            info.size = len(content)
-            tar.addfile(info, BytesIO(content.encode()))
+            add_to_tar(path, content)
 
     return dest.absolute().as_uri()
 
@@ -85,7 +102,7 @@ def app_listings_uri(tmp_path):
                     {
                         "app_name": "glean-app",
                         "app_channel": "beta",
-                        "canonical_app_name": "Glean App",
+                        "canonical_app_name": "Glean App Beta",
                         "bq_dataset_family": "glean_app_beta",
                     },
                 ]
@@ -95,7 +112,29 @@ def app_listings_uri(tmp_path):
     return dest.absolute().as_uri()
 
 
-def test_namespaces(runner, custom_namespaces, generated_sql_uri, app_listings_uri):
+@pytest.fixture
+def glean_apps():
+    return [
+        {
+            "app_name": "glean-app",
+            "canonical_app_name": "Glean App",
+            "channels": [
+                {
+                    "channel": "release",
+                    "dataset": "glean_app",
+                },
+                {
+                    "channel": "beta",
+                    "dataset": "glean_app_beta",
+                },
+            ],
+        }
+    ]
+
+
+def test_namespaces_full(
+    runner, custom_namespaces, generated_sql_uri, app_listings_uri
+):
     with runner.isolated_filesystem():
         result = runner.invoke(
             namespaces,
@@ -116,6 +155,7 @@ def test_namespaces(runner, custom_namespaces, generated_sql_uri, app_listings_u
         except Exception as e:
             # use exception chaining to expose original traceback
             raise e from result.exception
+        print(Path("namespaces.yaml").read_text())
         assert (
             dedent(
                 """
@@ -132,18 +172,45 @@ def test_namespaces(runner, custom_namespaces, generated_sql_uri, app_listings_u
                       type: ping_explore
                       views:
                         base_view: baseline
+                    growth_accounting:
+                      type: growth_accounting_explore
+                      views:
+                        base_view: growth_accounting
                   views:
                     baseline:
                     - channel: release
-                      is_ping_table: true
                       table: mozdata.glean_app.baseline
                     - channel: beta
-                      is_ping_table: true
                       table: mozdata.glean_app_beta.baseline
-                    baseline_clients_daily:
-                    - channel: release
-                      table: mozdata.glean_app.baseline_clients_daily
+                    growth_accounting:
+                    - table: mozdata.glean_app.baseline_clients_last_seen
                 """
             ).lstrip()
             == Path("namespaces.yaml").read_text()
         )
+
+
+def test_get_glean_apps(app_listings_uri, glean_apps):
+    assert _get_glean_apps(app_listings_uri) == glean_apps
+
+
+def test_get_looker_views(glean_apps, generated_sql_uri):
+    db_views = _get_db_views(generated_sql_uri)
+    views = _get_looker_views(glean_apps[0], db_views)
+    assert views == [
+        PingView(
+            "baseline",
+            [
+                {"channel": "release", "table": "mozdata.glean_app.baseline"},
+                {"channel": "beta", "table": "mozdata.glean_app_beta.baseline"},
+            ],
+        ),
+        GrowthAccountingView(
+            [
+                {
+                    "channel": "release",
+                    "table": "mozdata.glean_app.baseline_clients_daily",
+                }
+            ]
+        ),
+    ]


### PR DESCRIPTION
Also created a few more functions and cleaned up `namespaces.py`, and added some more tests for those functions.

This also removes the `_daily` tables, as right now we only create explores for ping tables and _last_seen tables (as the growth_accounting explore).

(No implementation yet of that explore, this just updates the namespaces.yaml)