### PR TITLE
CLI for update spoke with new namespaces

### DIFF
--- a/generator/__init__.py
+++ b/generator/__init__.py
@@ -6,11 +6,16 @@ import click
 
 from .lookml import lookml
 from .namespaces import namespaces
+from .spoke import update_spoke
 
 
 def cli(prog_name=None):
     """Generate and run CLI."""
-    commands = {"namespaces": namespaces, "lookml": lookml}
+    commands = {
+        "namespaces": namespaces,
+        "lookml": lookml,
+        "update-spoke": update_spoke,
+    }
 
     @click.group(commands=commands)
     def group():

--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -64,8 +64,11 @@ def generate_directories(namespaces: Dict[str, NamespaceDict], spoke_dir: Path):
 
         (spoke_dir / namespace).mkdir()
         (spoke_dir / namespace / "views").mkdir()
+        (spoke_dir / namespace / "views" / ".gitkeep").touch()
         (spoke_dir / namespace / "explores").mkdir()
+        (spoke_dir / namespace / "explores" / ".gitkeep").touch()
         (spoke_dir / namespace / "dashboards").mkdir()
+        (spoke_dir / namespace / "explores" / ".gitkeep").touch()
 
         generate_model(spoke_dir, namespace, defn)
 

--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -1,0 +1,89 @@
+"""Generate directories and models for new namespaces."""
+
+from pathlib import Path
+from typing import Dict, List, TypedDict
+
+import click
+import lkml
+import yaml
+
+from .lookml import ViewDict
+
+
+class ExploreDict(TypedDict):
+    """Represent an explore definition."""
+
+    type: str
+    views: List[Dict[str, str]]
+
+
+class NamespaceDict(TypedDict):
+    """Represent a Namespace definition."""
+
+    views: ViewDict
+    explores: ExploreDict
+    canonical_app_name: str
+
+
+def generate_model(spoke_path: Path, name: str, namespace_defn: NamespaceDict) -> Path:
+    """
+    Generate a model file for a namespace.
+
+    We want these to have a nice label and a unique name.
+    We only import explores and dashboards, as we want those
+    to auto-import upon generation.
+
+    Views are not imported by default, since they should
+    be added one-by-one if they are included in an explore.
+    """
+    model_defn = {
+        "connection": "telemetry",
+        "label": namespace_defn["canonical_app_name"],
+        "includes": [
+            f"//looker-hub/{name}/explores/*",
+            f"//looker-hub/{name}/dashboards/*",
+            "views/*",
+            "explores/*",
+            "dashboards/*",
+        ],
+    }
+
+    path = spoke_path / name / f"{name}.model.lkml"
+    path.write_text(lkml.dump(model_defn))
+
+    return path
+
+
+def generate_directories(namespaces: Dict[str, NamespaceDict], spoke_dir: Path):
+    """Generate directories and model for a namespace, if it doesn't exist."""
+    existing_dirs = {p.name for p in spoke_dir.iterdir()}
+    for namespace, defn in namespaces.items():
+        if namespace in existing_dirs:
+            # already generated, skip this namespace
+            continue
+
+        (spoke_dir / namespace).mkdir()
+        (spoke_dir / namespace / "views").mkdir()
+        (spoke_dir / namespace / "explores").mkdir()
+        (spoke_dir / namespace / "dashboards").mkdir()
+
+        generate_model(spoke_dir, namespace, defn)
+
+
+@click.command(help=__doc__)
+@click.option(
+    "--namespaces",
+    default="namespaces.yaml",
+    type=click.File(),
+    help="Path to the namespaces.yaml file.",
+)
+@click.option(
+    "--spoke-dir",
+    default="looker-spoke-default",
+    type=click.Path(file_okay=False, dir_okay=True, writable=True),
+    help="Directory containing the Looker spoke.",
+)
+def update_spoke(namespaces, spoke_dir):
+    """Generate updates to spoke project."""
+    _namespaces = yaml.safe_load(namespaces)
+    generate_directories(_namespaces, Path(spoke_dir))

--- a/tests/test_spoke.py
+++ b/tests/test_spoke.py
@@ -1,0 +1,70 @@
+import lkml
+import pytest
+
+from generator.spoke import generate_directories
+
+
+@pytest.fixture()
+def namespaces() -> dict:
+    return {
+        "glean-app": {
+            "canonical_app_name": "Glean App",
+            "views": {
+                "baseline": {
+                    "type": "ping_view",
+                    "tables": [
+                        {
+                            "channel": "release",
+                            "table": "mozdata.glean_app.baseline",
+                        }
+                    ],
+                }
+            },
+            "explores": {
+                "baseline": {"type": "ping_explore", "views": {"base_view": "baseline"}}
+            },
+        }
+    }
+
+
+def test_generate_directories(namespaces, tmp_path):
+    generate_directories(namespaces, tmp_path)
+    dirs = list(tmp_path.iterdir())
+    assert dirs == [tmp_path / "glean-app"]
+
+    app_path = tmp_path / "glean-app/"
+    sub_dirs = set(app_path.iterdir())
+    assert sub_dirs == {
+        app_path / "views",
+        app_path / "explores",
+        app_path / "dashboards",
+        app_path / "glean-app.model.lkml",
+    }
+
+
+def test_existing_dir(namespaces, tmp_path):
+    generate_directories(namespaces, tmp_path)
+    tmp_file = tmp_path / "glean-app" / "tmp-file"
+    tmp_file.write_text("hello, world")
+
+    generate_directories(namespaces, tmp_path)
+
+    # We shouldn't overwrite this dir
+    assert tmp_file.is_file()
+
+
+def test_generate_model(namespaces, tmp_path):
+    generate_directories(namespaces, tmp_path)
+    expected = {
+        "connection": "telemetry",
+        "label": "Glean App",
+        "includes": [
+            "//looker-hub/glean-app/explores/*",
+            "//looker-hub/glean-app/dashboards/*",
+            "views/*",
+            "explores/*",
+            "dashboards/*",
+        ],
+    }
+    actual = lkml.load((tmp_path / "glean-app" / "glean-app.model.lkml").read_text())
+    assert expected == actual


### PR DESCRIPTION
This assumes the spoke repo is available, and generates directories and a model for namespaces that don't have one yet. Will add to deploy via scripts in https://github.com/mozilla/lookml-generator/pull/32 once that merges.