### PR TITLE
Configure model after creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN groupadd --gid ${USER_ID} ${GROUP_ID} && \
 
 # For grpc https://github.com/grpc/grpc/issues/24556#issuecomment-751797589
 RUN apt-get update -qqy && \
-    apt-get install -qqy python-dev build-essential git
+    apt-get install -qqy python-dev build-essential git curl
 
 COPY --from=google/cloud-sdk:alpine /google-cloud-sdk /google-cloud-sdk
 ENV PATH /google-cloud-sdk/bin:$PATH

--- a/bin/generate
+++ b/bin/generate
@@ -208,6 +208,13 @@ function generate_looker_content() {
   popd
 }
 
+function hit_looker_webhooks() {
+  # These webhooks ensure production is up-to-date.
+  # See https://help.looker.com/hc/en-us/articles/360001288268-Deploy-Webhook-Pulling-From-Remote-Git-Repository
+  curl "$LOOKER_INSTANCE_URI/webhooks/projects/looker-hub/deploy"
+  curl "$LOOKER_INSTANCE_URI/webhooks/projects/looker-spoke-default/deploy"
+}
+
 function main() {
   pushd .
   cd /app
@@ -235,6 +242,8 @@ function main() {
 
   # Update Looker content
   generate_looker_content
+  hit_looker_webhooks
+
   popd
 }
 

--- a/bin/generate
+++ b/bin/generate
@@ -212,7 +212,7 @@ function hit_looker_webhooks() {
   # These webhooks ensure production is up-to-date.
   # See https://help.looker.com/hc/en-us/articles/360001288268-Deploy-Webhook-Pulling-From-Remote-Git-Repository
   curl "$LOOKER_INSTANCE_URI/webhooks/projects/looker-hub/deploy"
-  curl "$LOOKER_INSTANCE_URI/webhooks/projects/looker-spoke-default/deploy"
+  curl "$LOOKER_INSTANCE_URI/webhooks/projects/spoke-default/deploy"
 }
 
 function main() {

--- a/generator/content.py
+++ b/generator/content.py
@@ -8,10 +8,13 @@ import looker_sdk
 import yaml
 
 
-def _setup_env_with_looker_creds():
-    client_id = os.environ["LOOKER_API_CLIENT_ID"]
-    client_secret = os.environ["LOOKER_API_CLIENT_SECRET"]
-    instance = os.environ["LOOKER_INSTANCE_URI"]
+def _setup_env_with_looker_creds() -> bool:
+    client_id = os.environ.get("LOOKER_API_CLIENT_ID")
+    client_secret = os.environ.get("LOOKER_API_CLIENT_SECRET")
+    instance = os.environ.get("LOOKER_INSTANCE_URI")
+
+    if client_id is None or client_secret is None or instance is None:
+        return False
 
     os.environ["LOOKERSDK_BASE_URL"] = instance
     os.environ["LOOKERSDK_API_VERSION"] = "3.1"
@@ -19,6 +22,8 @@ def _setup_env_with_looker_creds():
     os.environ["LOOKERSDK_TIMEOUT"] = "120"
     os.environ["LOOKERSDK_CLIENT_ID"] = client_id
     os.environ["LOOKERSDK_CLIENT_SECRET"] = client_secret
+
+    return True
 
 
 def _get_id_from_list(arr: Sequence[Any], item: str) -> int:

--- a/generator/content.py
+++ b/generator/content.py
@@ -8,7 +8,12 @@ import looker_sdk
 import yaml
 
 
-def _setup_env_with_looker_creds() -> bool:
+def setup_env_with_looker_creds() -> bool:
+    """
+    Set up env with looker credentials.
+
+    Returns TRUE if the config is complete.
+    """
     client_id = os.environ.get("LOOKER_API_CLIENT_ID")
     client_secret = os.environ.get("LOOKER_API_CLIENT_SECRET")
     instance = os.environ.get("LOOKER_INSTANCE_URI")
@@ -148,5 +153,5 @@ def generate_folders(namespaces: dict):
 )
 def generate_content(namespaces):
     """Generate content folders."""
-    _setup_env_with_looker_creds()
+    setup_env_with_looker_creds()
     generate_folders(yaml.safe_load(namespaces))

--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -70,7 +70,9 @@ def configure_model(sdk: looker_sdk.methods.Looker31SDK, model_name: str):
     )
 
 
-def generate_directories(namespaces: Dict[str, NamespaceDict], spoke_dir: Path):
+def generate_directories(
+    namespaces: Dict[str, NamespaceDict], spoke_dir: Path, sdk_setup=False
+):
     """Generate directories and model for a namespace, if it doesn't exist."""
     sdk = looker_sdk.init31()
     logging.info("Looker SDK 3.1 initialized successfully.")
@@ -90,7 +92,9 @@ def generate_directories(namespaces: Dict[str, NamespaceDict], spoke_dir: Path):
         (spoke_dir / namespace / "explores" / ".gitkeep").touch()
 
         generate_model(spoke_dir, namespace, defn)
-        configure_model(sdk, namespace)
+
+        if sdk_setup:
+            configure_model(sdk, namespace)
 
 
 @click.command(help=__doc__)
@@ -109,5 +113,5 @@ def generate_directories(namespaces: Dict[str, NamespaceDict], spoke_dir: Path):
 def update_spoke(namespaces, spoke_dir):
     """Generate updates to spoke project."""
     _namespaces = yaml.safe_load(namespaces)
-    _setup_env_with_looker_creds()
-    generate_directories(_namespaces, Path(spoke_dir))
+    sdk_setup = _setup_env_with_looker_creds()
+    generate_directories(_namespaces, Path(spoke_dir), sdk_setup)

--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -1,5 +1,6 @@
 """Generate directories and models for new namespaces."""
 
+import logging
 from pathlib import Path
 from typing import Dict, List, TypedDict
 
@@ -38,6 +39,7 @@ def generate_model(spoke_path: Path, name: str, namespace_defn: NamespaceDict) -
     Views are not imported by default, since they should
     be added one-by-one if they are included in an explore.
     """
+    logging.info(f"Generating model {name}...")
     model_defn = {
         "connection": "telemetry",
         "label": namespace_defn["canonical_app_name"],
@@ -55,14 +57,18 @@ def generate_model(spoke_path: Path, name: str, namespace_defn: NamespaceDict) -
 
     return path
 
-def configure_model(sdk: looker_sdk.methods.Looker31SDK, model_name: str)
+
+def configure_model(sdk: looker_sdk.methods.Looker31SDK, model_name: str):
+    """Configure a Looker model by name."""
+    logging.info(f"Configuring model {model_name}...")
     sdk.create_lookml_model(
-        sdk.models.WriteLookmlModel(
+        looker_sdk.models.WriteLookmlModel(
             allowed_db_connection_names=["telemetry"],
             name=model_name,
             project_name="spoke-default",
         )
     )
+
 
 def generate_directories(namespaces: Dict[str, NamespaceDict], spoke_dir: Path):
     """Generate directories and model for a namespace, if it doesn't exist."""
@@ -84,6 +90,7 @@ def generate_directories(namespaces: Dict[str, NamespaceDict], spoke_dir: Path):
         (spoke_dir / namespace / "explores" / ".gitkeep").touch()
 
         generate_model(spoke_dir, namespace, defn)
+        configure_model(sdk, namespace)
 
 
 @click.command(help=__doc__)

--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -5,8 +5,10 @@ from typing import Dict, List, TypedDict
 
 import click
 import lkml
+import looker_sdk
 import yaml
 
+from .content import _setup_env_with_looker_creds
 from .lookml import ViewDict
 
 
@@ -53,9 +55,20 @@ def generate_model(spoke_path: Path, name: str, namespace_defn: NamespaceDict) -
 
     return path
 
+def configure_model(sdk: looker_sdk.methods.Looker31SDK, model_name: str)
+    sdk.create_lookml_model(
+        sdk.models.WriteLookmlModel(
+            allowed_db_connection_names=["telemetry"],
+            name=model_name,
+            project_name="spoke-default",
+        )
+    )
 
 def generate_directories(namespaces: Dict[str, NamespaceDict], spoke_dir: Path):
     """Generate directories and model for a namespace, if it doesn't exist."""
+    sdk = looker_sdk.init31()
+    logging.info("Looker SDK 3.1 initialized successfully.")
+
     existing_dirs = {p.name for p in spoke_dir.iterdir()}
     for namespace, defn in namespaces.items():
         if namespace in existing_dirs:
@@ -89,4 +102,5 @@ def generate_directories(namespaces: Dict[str, NamespaceDict], spoke_dir: Path):
 def update_spoke(namespaces, spoke_dir):
     """Generate updates to spoke project."""
     _namespaces = yaml.safe_load(namespaces)
+    _setup_env_with_looker_creds()
     generate_directories(_namespaces, Path(spoke_dir))

--- a/generator/views.py
+++ b/generator/views.py
@@ -250,7 +250,7 @@ class GrowthAccountingView(View):
         },
     ]
 
-    default_measures: List[Dict[str, Union[str, Dict[str, str]]]] = [
+    default_measures: List[Dict[str, Union[str, List[Dict[str, str]]]]] = [
         {
             "name": "overall_active_previous",
             "type": "count",
@@ -454,7 +454,7 @@ class GrowthAccountingView(View):
 
         return [view_defn]
 
-    def get_measures(self) -> List[Dict[str, Union[str, Dict[str, str]]]]:
+    def get_measures(self) -> List[Dict[str, Union[str, List[Dict[str, str]]]]]:
         """Generate measures for the Growth Accounting Framework."""
         return deepcopy(GrowthAccountingView.default_measures)
 

--- a/generator/views.py
+++ b/generator/views.py
@@ -254,65 +254,65 @@ class GrowthAccountingView(View):
         {
             "name": "overall_active_previous",
             "type": "count",
-            "filters": {"active_last_week": "yes"},
+            "filters": [{"active_last_week": "yes"}],
         },
         {
             "name": "overall_active_current",
             "type": "count",
-            "filters": {"active_this_week": "yes"},
+            "filters": [{"active_this_week": "yes"}],
         },
         {
             "name": "overall_resurrected",
             "type": "count",
-            "filters": {
-                "new_last_week": "no",
-                "new_this_week": "no",
-                "active_last_week": "no",
-                "active_this_week": "yes",
-            },
+            "filters": [
+                {"new_last_week": "no"},
+                {"new_this_week": "no"},
+                {"active_last_week": "no"},
+                {"active_this_week": "yes"},
+            ],
         },
         {
             "name": "new_users",
             "type": "count",
-            "filters": {"new_this_week": "yes", "active_this_week": "yes"},
+            "filters": [{"new_this_week": "yes"}, {"active_this_week": "yes"}],
         },
         {
             "name": "established_users_returning",
             "type": "count",
-            "filters": {
-                "new_last_week": "no",
-                "new_this_week": "no",
-                "active_last_week": "yes",
-                "active_this_week": "yes",
-            },
+            "filters": [
+                {"new_last_week": "no"},
+                {"new_this_week": "no"},
+                {"active_last_week": "yes"},
+                {"active_this_week": "yes"},
+            ],
         },
         {
             "name": "new_users_returning",
             "type": "count",
-            "filters": {
-                "new_last_week": "yes",
-                "active_last_week": "yes",
-                "active_this_week": "yes",
-            },
+            "filters": [
+                {"new_last_week": "yes"},
+                {"active_last_week": "yes"},
+                {"active_this_week": "yes"},
+            ],
         },
         {
             "name": "new_users_churned_count",
             "type": "count",
-            "filters": {
-                "new_last_week": "yes",
-                "active_last_week": "yes",
-                "active_this_week": "no",
-            },
+            "filters": [
+                {"new_last_week": "yes"},
+                {"active_last_week": "yes"},
+                {"active_this_week": "no"},
+            ],
         },
         {
             "name": "established_users_churned_count",
             "type": "count",
-            "filters": {
-                "new_last_week": "no",
-                "new_this_week": "no",
-                "active_last_week": "yes",
-                "active_this_week": "no",
-            },
+            "filters": [
+                {"new_last_week": "no"},
+                {"new_this_week": "no"},
+                {"active_last_week": "yes"},
+                {"active_this_week": "no"},
+            ],
         },
         {
             "name": "new_users_churned",

--- a/tests/test_spoke.py
+++ b/tests/test_spoke.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import Mock, patch
 
 import lkml
@@ -30,6 +31,7 @@ def namespaces() -> dict:
 
 
 @patch("generator.spoke.looker_sdk")
+@patch.dict(os.environ, {"LOOKER_INSTANCE_URI": "https://mozilladev.cloud.looker.com"})
 def test_generate_directories(looker_sdk, namespaces, tmp_path):
     sdk = looker_sdk.init31()
     sdk.search_model_sets.return_value = [Mock(models=["model"], id=1)]
@@ -72,6 +74,7 @@ def test_generate_directories_no_sdk(looker_sdk, namespaces, tmp_path):
 
 
 @patch("generator.spoke.looker_sdk")
+@patch.dict(os.environ, {"LOOKER_INSTANCE_URI": "https://mozilladev.cloud.looker.com"})
 def test_existing_dir(looker_sdk, namespaces, tmp_path):
     sdk = looker_sdk.init31()
     sdk.search_model_sets.return_value = [Mock(models=["model"], id=1)]
@@ -87,6 +90,7 @@ def test_existing_dir(looker_sdk, namespaces, tmp_path):
 
 
 @patch("generator.spoke.looker_sdk")
+@patch.dict(os.environ, {"LOOKER_INSTANCE_URI": "https://mozilladev.cloud.looker.com"})
 def test_generate_model(looker_sdk, namespaces, tmp_path):
     sdk = looker_sdk.init31()
     sdk.search_model_sets.return_value = [Mock(models=["model"], id=1)]

--- a/tests/test_spoke.py
+++ b/tests/test_spoke.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import lkml
 import pytest
@@ -31,6 +31,9 @@ def namespaces() -> dict:
 
 @patch("generator.spoke.looker_sdk")
 def test_generate_directories(looker_sdk, namespaces, tmp_path):
+    sdk = looker_sdk.init31()
+    sdk.search_model_sets.return_value = [Mock(models=["model"], id=1)]
+
     generate_directories(namespaces, tmp_path, True)
     dirs = list(tmp_path.iterdir())
     assert dirs == [tmp_path / "glean-app"]
@@ -44,12 +47,14 @@ def test_generate_directories(looker_sdk, namespaces, tmp_path):
         app_path / "glean-app.model.lkml",
     }
 
-    sdk = looker_sdk.init31()
     sdk.create_lookml_model.assert_called_once()
 
 
 @patch("generator.spoke.looker_sdk")
 def test_generate_directories_no_sdk(looker_sdk, namespaces, tmp_path):
+    sdk = looker_sdk.init31()
+    sdk.search_model_sets.return_value = [Mock(models=["model"], id=1)]
+
     generate_directories(namespaces, tmp_path, False)
     dirs = list(tmp_path.iterdir())
     assert dirs == [tmp_path / "glean-app"]
@@ -63,12 +68,14 @@ def test_generate_directories_no_sdk(looker_sdk, namespaces, tmp_path):
         app_path / "glean-app.model.lkml",
     }
 
-    sdk = looker_sdk.init31()
     sdk.create_lookml_model.assert_not_called()
 
 
 @patch("generator.spoke.looker_sdk")
 def test_existing_dir(looker_sdk, namespaces, tmp_path):
+    sdk = looker_sdk.init31()
+    sdk.search_model_sets.return_value = [Mock(models=["model"], id=1)]
+
     generate_directories(namespaces, tmp_path, True)
     tmp_file = tmp_path / "glean-app" / "tmp-file"
     tmp_file.write_text("hello, world")
@@ -81,6 +88,9 @@ def test_existing_dir(looker_sdk, namespaces, tmp_path):
 
 @patch("generator.spoke.looker_sdk")
 def test_generate_model(looker_sdk, namespaces, tmp_path):
+    sdk = looker_sdk.init31()
+    sdk.search_model_sets.return_value = [Mock(models=["model"], id=1)]
+
     generate_directories(namespaces, tmp_path, True)
     expected = {
         "connection": "telemetry",

--- a/tests/test_spoke.py
+++ b/tests/test_spoke.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import lkml
 import pytest
 
@@ -27,7 +29,8 @@ def namespaces() -> dict:
     }
 
 
-def test_generate_directories(namespaces, tmp_path):
+@patch("generator.spoke.looker_sdk")
+def test_generate_directories(looker_sdk, namespaces, tmp_path):
     generate_directories(namespaces, tmp_path)
     dirs = list(tmp_path.iterdir())
     assert dirs == [tmp_path / "glean-app"]
@@ -41,8 +44,12 @@ def test_generate_directories(namespaces, tmp_path):
         app_path / "glean-app.model.lkml",
     }
 
+    sdk = looker_sdk.init31()
+    sdk.create_lookml_model.assert_called_once()
 
-def test_existing_dir(namespaces, tmp_path):
+
+@patch("generator.spoke.looker_sdk")
+def test_existing_dir(looker_sdk, namespaces, tmp_path):
     generate_directories(namespaces, tmp_path)
     tmp_file = tmp_path / "glean-app" / "tmp-file"
     tmp_file.write_text("hello, world")
@@ -53,7 +60,8 @@ def test_existing_dir(namespaces, tmp_path):
     assert tmp_file.is_file()
 
 
-def test_generate_model(namespaces, tmp_path):
+@patch("generator.spoke.looker_sdk")
+def test_generate_model(looker_sdk, namespaces, tmp_path):
     generate_directories(namespaces, tmp_path)
     expected = {
         "connection": "telemetry",

--- a/tests/test_spoke.py
+++ b/tests/test_spoke.py
@@ -31,7 +31,7 @@ def namespaces() -> dict:
 
 @patch("generator.spoke.looker_sdk")
 def test_generate_directories(looker_sdk, namespaces, tmp_path):
-    generate_directories(namespaces, tmp_path)
+    generate_directories(namespaces, tmp_path, True)
     dirs = list(tmp_path.iterdir())
     assert dirs == [tmp_path / "glean-app"]
 
@@ -49,8 +49,27 @@ def test_generate_directories(looker_sdk, namespaces, tmp_path):
 
 
 @patch("generator.spoke.looker_sdk")
+def test_generate_directories_no_sdk(looker_sdk, namespaces, tmp_path):
+    generate_directories(namespaces, tmp_path, False)
+    dirs = list(tmp_path.iterdir())
+    assert dirs == [tmp_path / "glean-app"]
+
+    app_path = tmp_path / "glean-app/"
+    sub_dirs = set(app_path.iterdir())
+    assert sub_dirs == {
+        app_path / "views",
+        app_path / "explores",
+        app_path / "dashboards",
+        app_path / "glean-app.model.lkml",
+    }
+
+    sdk = looker_sdk.init31()
+    sdk.create_lookml_model.assert_not_called()
+
+
+@patch("generator.spoke.looker_sdk")
 def test_existing_dir(looker_sdk, namespaces, tmp_path):
-    generate_directories(namespaces, tmp_path)
+    generate_directories(namespaces, tmp_path, True)
     tmp_file = tmp_path / "glean-app" / "tmp-file"
     tmp_file.write_text("hello, world")
 
@@ -62,7 +81,7 @@ def test_existing_dir(looker_sdk, namespaces, tmp_path):
 
 @patch("generator.spoke.looker_sdk")
 def test_generate_model(looker_sdk, namespaces, tmp_path):
-    generate_directories(namespaces, tmp_path)
+    generate_directories(namespaces, tmp_path, True)
     expected = {
         "connection": "telemetry",
         "label": "Glean App",


### PR DESCRIPTION
We've discovered on stage that the models are not configured after deploy.

We add that here to ease development lifecycle. I've tested on dev and this looks to be successful.

Webhooks ensure that the instance is up-to-date on production.