### PR TITLE
Add Fenix to allowlist

### DIFF
--- a/namespace_allowlist.yaml
+++ b/namespace_allowlist.yaml
@@ -1,2 +1,3 @@
 ---
 - burnham
+- fenix


### PR DESCRIPTION
I'm hesitant about merging this change just yet. I'm noticing some things about the explores that may not be backwards compatible if we enact them, and we are blocked from further stage deploys if we merge this as-is.