### PR TITLE
Don't configure model if already exists

### DIFF
--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -70,6 +70,13 @@ def configure_model(sdk: looker_sdk.methods.Looker31SDK, model_name: str):
     instance = os.environ["LOOKER_INSTANCE_URI"]
     logging.info(f"Configuring model {model_name}...")
 
+    try:
+        sdk.lookml_model(model_name)
+        logging.info("Model is configured!")
+        return
+    except looker_sdk.error.SDKError:
+        pass
+
     sdk.create_lookml_model(
         looker_sdk.models.WriteLookmlModel(
             allowed_db_connection_names=["telemetry"],

--- a/tests/test_spoke.py
+++ b/tests/test_spoke.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import Mock, patch
 
 import lkml
+import looker_sdk as _looker_sdk
 import pytest
 
 from generator.spoke import generate_directories
@@ -35,6 +36,8 @@ def namespaces() -> dict:
 def test_generate_directories(looker_sdk, namespaces, tmp_path):
     sdk = looker_sdk.init31()
     sdk.search_model_sets.return_value = [Mock(models=["model"], id=1)]
+    sdk.lookml_model.side_effect = _looker_sdk.error.SDKError
+    looker_sdk.error = Mock(SDKError=_looker_sdk.error.SDKError)
 
     generate_directories(namespaces, tmp_path, True)
     dirs = list(tmp_path.iterdir())


### PR DESCRIPTION
This mainly effects dev, but could effect prod. Basically what happens is the looker sdk fails if the model config already exists. Now we do only try to config a model if the directory for that namespaces is missing, but the problem was that we haven't been merging in the changes immediately while developing, but the model config is done while the script runs. This ends us up in an inconsistent state where the model is configured but there is no associated lookml file.

We work around that here by first checking if the model config exists. 