### PR TITLE
Updates to `namespaces.yaml`

### DIFF
--- a/generator/content.py
+++ b/generator/content.py
@@ -49,7 +49,7 @@ def generate_folders(namespaces: dict):
     shared_folder_id = _get_id_from_list(shared_folders, "Shared folders")
 
     for namespace, defn in namespaces.items():
-        pretty_name = defn["canonical_app_name"]
+        pretty_name = defn["pretty_name"]
         owners = defn["owners"]
 
         try:

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -87,10 +87,11 @@ def _get_glean_apps(
         if channels:
             apps.append(
                 {
-                    "app_name": app_name,
-                    "canonical_app_name": canonical_app_name,
+                    "name": app_name,
+                    "pretty_name": canonical_app_name,
                     "channels": channels,
                     "owners": emails,
+                    "glean_app": True,
                 }
             )
 
@@ -105,7 +106,7 @@ def _get_looker_views(
 
     for klass in view_types.values():
         for view in klass.from_db_views(  # type: ignore
-            app["app_name"], app["channels"], db_views
+            app["name"], app["channels"], db_views
         ):
             if view.name in view_names:
                 raise KeyError(
@@ -165,11 +166,12 @@ def namespaces(custom_namespaces, generated_sql_uri, app_listings_uri, allowlist
         explores = _get_explores(looker_views)
         views_as_dict = {view.name: view.as_dict() for view in looker_views}
 
-        namespaces[app["app_name"]] = {
+        namespaces[app["name"]] = {
             "owners": app["owners"],
-            "canonical_app_name": app["canonical_app_name"],
+            "pretty_name": app["pretty_name"],
             "views": views_as_dict,
             "explores": explores,
+            "glean_app": True,
         }
 
     if custom_namespaces is not None:

--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -32,7 +32,8 @@ class NamespaceDict(TypedDict):
 
     views: ViewDict
     explores: ExploreDict
-    canonical_app_name: str
+    pretty_name: str
+    glean_app: bool
 
 
 def generate_model(spoke_path: Path, name: str, namespace_defn: NamespaceDict) -> Path:
@@ -49,7 +50,7 @@ def generate_model(spoke_path: Path, name: str, namespace_defn: NamespaceDict) -
     logging.info(f"Generating model {name}...")
     model_defn = {
         "connection": "telemetry",
-        "label": namespace_defn["canonical_app_name"],
+        "label": namespace_defn["pretty_name"],
         "includes": [
             f"//looker-hub/{name}/explores/*",
             f"//looker-hub/{name}/dashboards/*",

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -10,7 +10,8 @@ from generator.content import generate_folders
 def namespaces():
     return {
         "burnham": {
-            "canonical_app_name": "Burnham",
+            "pretty_name": "Burnham",
+            "glean_app": True,
             "owners": ["owner@mozilla.com"],
             "explores": [],
             "views": [],

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -123,7 +123,8 @@ def test_lookml_actual(runner, tmp_path):
         dedent(
             """
             custom:
-              canonical_app_name: Custom
+              pretty_name: Custom
+              glean_app: false
               views:
                 baseline:
                   type: ping_view
@@ -131,7 +132,8 @@ def test_lookml_actual(runner, tmp_path):
                   - channel: release
                     table: mozdata.custom.baseline
             glean-app:
-              canonical_app_name: Glean App
+              pretty_name: Glean App
+              glean_app: true
               views:
                 baseline:
                   type: ping_view
@@ -434,7 +436,8 @@ def test_duplicate_dimension(runner, tmp_path):
         dedent(
             """
             custom:
-              canonical_app_name: Custom
+              pretty_name: Custom
+              glean_app: false
               views:
                 baseline:
                   type: ping_view
@@ -466,7 +469,8 @@ def test_duplicate_measure(runner, tmp_path):
         dedent(
             """
             custom:
-              canonical_app_name: Custom
+              pretty_name: Custom
+              glean_app: false
               views:
                 baseline:
                   type: ping_view

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -30,9 +30,10 @@ def custom_namespaces(tmp_path):
         dedent(
             """
             custom:
+              glean_app: false
+              pretty_name: Custom
               owners:
               - custom-owner@allizom.com
-              canonical_app_name: Custom
               views:
                 baseline:
                   type: ping_view
@@ -40,9 +41,9 @@ def custom_namespaces(tmp_path):
                   - channel: release
                     table: mozdata.custom.baseline
             disallowed:
+              pretty_name: Disallowed
               owners:
               - disallowed-owner@allizom.com
-              canonical_app_name: Disallowed
               views:
                 baseline:
                   type: ping_view
@@ -147,8 +148,9 @@ def app_listings_uri(tmp_path):
 def glean_apps():
     return [
         {
-            "app_name": "glean-app",
-            "canonical_app_name": "Glean App",
+            "name": "glean-app",
+            "glean_app": True,
+            "pretty_name": "Glean App",
             "owners": [
                 "glean-app-owner@allizom.com",
             ],
@@ -195,9 +197,10 @@ def test_namespaces_full(
             dedent(
                 """
                 custom:
-                  canonical_app_name: Custom
+                  glean_app: false
                   owners:
                   - custom-owner@allizom.com
+                  pretty_name: Custom
                   views:
                     baseline:
                       tables:
@@ -205,7 +208,6 @@ def test_namespaces_full(
                         table: mozdata.custom.baseline
                       type: ping_view
                 glean-app:
-                  canonical_app_name: Glean App
                   explores:
                     baseline:
                       type: ping_explore
@@ -215,8 +217,10 @@ def test_namespaces_full(
                       type: growth_accounting_explore
                       views:
                         base_view: growth_accounting
+                  glean_app: true
                   owners:
                   - glean-app-owner@allizom.com
+                  pretty_name: Glean App
                   views:
                     baseline:
                       tables:

--- a/tests/test_spoke.py
+++ b/tests/test_spoke.py
@@ -11,7 +11,8 @@ from generator.spoke import generate_directories
 def namespaces() -> dict:
     return {
         "glean-app": {
-            "canonical_app_name": "Glean App",
+            "pretty_name": "Glean App",
+            "glean_app": True,
             "views": {
                 "baseline": {
                     "type": "ping_view",


### PR DESCRIPTION
- Use pretty_name instead of canonical_app_name
- Add `glean_app` to indicate a namespace is glean