### PR TITLE
Add numbers_that_matter namespace

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1,1 +1,17 @@
 ---
+duet:
+  glean_app: false
+  owners:
+  - ascholtz@mozilla.com
+  pretty_name: DUET
+  views:
+    install:
+      type: ping_view
+      tables:
+      - channel: release
+        table: mozdata.firefox_installer.install
+    new_profile:
+      type: ping_view
+      tables:
+      - channel: release
+        table: mozdata.telemetry.new_profile

--- a/namespace_allowlist.yaml
+++ b/namespace_allowlist.yaml
@@ -1,2 +1,3 @@
 ---
 - burnham
+- duet


### PR DESCRIPTION
I'm not entirely sure what the process looks like here. Once this gets merged, will the namespace be automatically generated and views will be added to looker-hub? Or do I have to open a PR against looker-hub to add what was generated?

The generated output: https://github.com/scholtzan/looker-hub/tree/ascholtz-numbers-that-matter-generation-test-1