### PR TITLE
Require date and channel filters in ping explores

### DIFF
--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import lkml
 
 
 @dataclass
@@ -11,6 +14,7 @@ class Explore:
 
     name: str
     views: Dict[str, str]
+    views_path: Optional[Path] = None
     type: str = field(init=False)
 
     def to_dict(self) -> dict:
@@ -26,6 +30,12 @@ class Explore:
         return [view for _, view in self.views.items()]
 
     @staticmethod
-    def from_dict(name: str, defn: dict) -> Explore:
+    def from_dict(name: str, defn: dict, views_path: Path) -> Explore:
         """Get an instance of an explore from a namespace definition."""
         raise NotImplementedError("Only implemented in subclasses")
+
+    def get_view_lookml(self, view: str) -> dict:
+        """Get the LookML for a view."""
+        if self.views_path is not None:
+            return lkml.load((self.views_path / f"{view}.view.lkml").read_text())
+        raise Exception("Missing view path for get_view_lookml")

--- a/generator/explores/growth_accounting_explore.py
+++ b/generator/explores/growth_accounting_explore.py
@@ -1,6 +1,7 @@
 """Growth Accounting explore type."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Iterator, List
 
 from ..views import View
@@ -34,6 +35,6 @@ class GrowthAccountingExplore(Explore):
                 )
 
     @staticmethod
-    def from_dict(name: str, defn: dict) -> GrowthAccountingExplore:
+    def from_dict(name: str, defn: dict, views_path: Path) -> GrowthAccountingExplore:
         """Get an instance of this explore from a dictionary definition."""
-        return GrowthAccountingExplore(name, defn["views"])
+        return GrowthAccountingExplore(name, defn["views"], views_path)

--- a/generator/explores/ping_explore.py
+++ b/generator/explores/ping_explore.py
@@ -1,6 +1,7 @@
 """Ping explore type."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Iterator, List
 
 from ..views import PingView, View
@@ -14,9 +15,30 @@ class PingExplore(Explore):
 
     def to_lookml(self) -> dict:
         """Generate LookML to represent this explore."""
+        filters = [{"submission_date": '"28 days"'}]
+        view = self.views["base_view"]
+
+        # Add a default filter on channel, if it's present in the view
+        channel_params = [
+            param
+            for _view_defn in self.get_view_lookml(view)["views"]
+            for param in _view_defn.get("parameters", [])
+            if _view_defn["name"] == view and param["name"] == "channel"
+        ]
+
+        if channel_params:
+            allowed_values = channel_params[0]["allowed_values"]
+            default_value = next(
+                (value for value in allowed_values if value["label"] == "Release"),
+                allowed_values[0],
+            )["value"]
+
+            filters.append({"channel": f'"{default_value}"'})
+
         return {
             "name": self.name,
             "view_name": self.views["base_view"],
+            "always_filter": filters,
         }
 
     @staticmethod
@@ -27,6 +49,6 @@ class PingExplore(Explore):
                 yield PingExplore(view.name, {"base_view": view.name})
 
     @staticmethod
-    def from_dict(name: str, defn: dict) -> PingExplore:
+    def from_dict(name: str, defn: dict, views_path: Path) -> PingExplore:
         """Get an instance of this explore from a name and dictionary definition."""
-        return PingExplore(name, defn["views"])
+        return PingExplore(name, defn["views"], views_path)

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -159,7 +159,7 @@ def test_lookml_actual(runner, tmp_path):
     )
     with runner.isolated_filesystem():
         with patch("google.cloud.bigquery.Client", MockClient):
-            _lookml(Path(namespaces.absolute()).read_text(), "looker-hub/")
+            _lookml(open(namespaces), "looker-hub/")
         expected = {
             "views": [
                 {


### PR DESCRIPTION
Only requires a channel when it is present in the view. Fixes #59, Fixes #60.