### PR TITLE
Add sums and client counts for `metrics.counter`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 92
+max-line-length = 120
 ignore = E203, W503

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 venv/
 namespaces.yaml
 looker-hub/
+.env

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -46,7 +46,7 @@ def _get_views_from_dict(
 ) -> Iterable[View]:
     for view_name, view_info in views.items():
         yield VIEW_TYPES[view_info["type"]].from_dict(  # type: ignore
-            view_name, view_info
+            namespace, view_name, view_info
         )
 
 

--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -46,15 +46,12 @@ class GleanPingView(PingView):
 
         Raise ClickException if dimensions result in duplicate measures.
         """
-        print(f"Generation measures for table {table}")
         measures = super().get_measures(dimensions, table)
         client_id_field = self._get_client_id(dimensions, table)
 
         for dimension in dimensions:
-            print(f"Dimension: {dimension}")
             dimension_name = dimension["name"]
             if "metrics__counter__" in dimension_name:
-                print("Is counter!")
                 # handle the counters in the metric ping
                 name = "__".join(dimension_name.split("__")[1:])
                 measures += [

--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -13,10 +13,6 @@ class GleanPingView(PingView):
     type: str = "glean_ping_view"
     allow_glean: bool = True
 
-    def __init__(self, name: str, tables: List[Dict[str, str]], **kwargs):
-        """Create instance of a GleanPingView."""
-        super().__init__(name, tables, **kwargs)
-
     def _get_links(self, dimension: dict) -> List[Dict[str, str]]:
         """Get a link annotation given a metric name."""
         name = self._get_name(dimension)
@@ -26,7 +22,7 @@ class GleanPingView(PingView):
                 "label": (f"Glean Dictionary reference for {title}"),
                 "url": (
                     f"https://dictionary.telemetry.mozilla.org"
-                    f"/apps/{self.name}/metrics/{name}"
+                    f"/apps/{self.namespace}/metrics/{name}"
                 ),
                 "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",
             }

--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -1,5 +1,8 @@
 """Class to describe a Glean Ping View."""
+from collections import Counter
 from typing import Any, Dict, List
+
+import click
 
 from .ping_view import PingView
 
@@ -35,3 +38,46 @@ class GleanPingView(PingView):
             self._annotate_dimension(d)
             for d in super().get_dimensions(bq_client, table)
         ]
+
+    def get_measures(self, dimensions: List[dict], table: str) -> List[Dict[str, str]]:
+        """Generate measures from a list of dimensions.
+
+        When no dimension-specific measures are found, return a single "count" measure.
+
+        Raise ClickException if dimensions result in duplicate measures.
+        """
+        measures = super().get_measures(dimensions, table)
+        client_id_field = self._get_client_id(dimensions, table)
+
+        for dimension in dimensions:
+            dimension_name = dimension["name"]
+            if "metrics__counter__" in dimension_name:
+                # handle the counters in the metric ping
+                name = dimension_name.ltrim("metrics__")
+                measures += [
+                    {
+                        "name": name,
+                        "type": "sum",
+                        "sql": f"${{{dimension_name}}}",
+                    },
+                    {
+                        "name": f"{name}_client_count",
+                        "type": "count_distinct",
+                        "sql": (
+                            f"case when ${{{dimension_name}}} > 0 then "
+                            f"${{{client_id_field}}}"
+                        ),
+                    },
+                ]
+
+        # check if there are any duplicate values, and report the first one that
+        # shows up
+        names = [measure["name"] for measure in measures]
+        duplicates = [k for k, v in Counter(names).items() if v > 1]
+        if duplicates:
+            name = duplicates[0]
+            raise click.ClickException(
+                f"duplicate measure {name!r} for table {table!r}"
+            )
+
+        return measures

--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -46,14 +46,17 @@ class GleanPingView(PingView):
 
         Raise ClickException if dimensions result in duplicate measures.
         """
+        print(f"Generation measures for table {table}")
         measures = super().get_measures(dimensions, table)
         client_id_field = self._get_client_id(dimensions, table)
 
         for dimension in dimensions:
+            print(f"Dimension: {dimension}")
             dimension_name = dimension["name"]
             if "metrics__counter__" in dimension_name:
+                print("Is counter!")
                 # handle the counters in the metric ping
-                name = dimension_name.ltrim("metrics__")
+                name = "__".join(dimension_name.split("__")[1:])
                 measures += [
                     {
                         "name": name,

--- a/generator/views/growth_accounting_view.py
+++ b/generator/views/growth_accounting_view.py
@@ -212,13 +212,19 @@ class GrowthAccountingView(View):
         },
     ]
 
-    def __init__(self, tables: List[Dict[str, str]]):
+    def __init__(self, namespace: str, tables: List[Dict[str, str]]):
         """Get an instance of a GrowthAccountingView."""
-        super().__init__("growth_accounting", GrowthAccountingView.type, tables)
+        super().__init__(
+            namespace, "growth_accounting", GrowthAccountingView.type, tables
+        )
 
     @classmethod
     def from_db_views(
-        klass, name: str, is_glean: bool, channels: List[Dict[str, str]], db_views: dict
+        klass,
+        namespace: str,
+        is_glean: bool,
+        channels: List[Dict[str, str]],
+        db_views: dict,
     ) -> Iterator[GrowthAccountingView]:
         """Get Growth Accounting Views from db views and app variants."""
         dataset = next(
@@ -228,12 +234,16 @@ class GrowthAccountingView(View):
 
         for view_id, references in db_views[dataset].items():
             if view_id == "baseline_clients_last_seen":
-                yield GrowthAccountingView([{"table": f"mozdata.{dataset}.{view_id}"}])
+                yield GrowthAccountingView(
+                    namespace, [{"table": f"mozdata.{dataset}.{view_id}"}]
+                )
 
     @classmethod
-    def from_dict(klass, name: str, _dict: ViewDict) -> GrowthAccountingView:
+    def from_dict(
+        klass, namespace: str, name: str, _dict: ViewDict
+    ) -> GrowthAccountingView:
         """Get a view from a name and dict definition."""
-        return GrowthAccountingView(_dict["tables"])
+        return GrowthAccountingView(namespace, _dict["tables"])
 
     def to_lookml(self, bq_client) -> List[dict]:
         """Generate LookML for this view."""

--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -73,6 +73,7 @@ class PingView(View):
         )
 
         # add measures
+        print(f"super: Getting measures for {table}")
         view_defn["measures"] = self.get_measures(dimensions, table)
 
         # parameterize table name

--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from itertools import filterfalse
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Union
 
 import click
 
@@ -114,7 +114,9 @@ class PingView(View):
             raise click.ClickException(f"Duplicate client_id dimension in {table!r}")
         return client_id_fields[0]
 
-    def get_measures(self, dimensions: List[dict], table: str) -> List[Dict[str, str]]:
+    def get_measures(
+        self, dimensions: List[dict], table: str
+    ) -> List[Dict[str, Union[str, List[Dict[str, str]]]]]:
         """Generate measures from a list of dimensions.
 
         When no dimension-specific measures are found, return a single "count" measure.
@@ -125,7 +127,7 @@ class PingView(View):
         # that we want to include in the view. We pull out the client id first
         # since we'll use it to calculate per-measure client counts.
         client_id_field = self._get_client_id(dimensions, table)
-        measures = [
+        measures: List[Dict[str, Union[str, List[Dict[str, str]]]]] = [
             {
                 "name": "clients",
                 "type": "count_distinct",

--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -73,7 +73,6 @@ class PingView(View):
         )
 
         # add measures
-        print(f"super: Getting measures for {table}")
         view_defn["measures"] = self.get_measures(dimensions, table)
 
         # parameterize table name

--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -17,13 +17,17 @@ class PingView(View):
     type: str = "ping_view"
     allow_glean: bool = False
 
-    def __init__(self, name: str, tables: List[Dict[str, str]], **kwargs):
+    def __init__(self, namespace: str, name: str, tables: List[Dict[str, str]]):
         """Create instance of a PingView."""
-        super().__init__(name, self.__class__.type, tables, **kwargs)
+        super().__init__(namespace, name, self.__class__.type, tables)
 
     @classmethod
     def from_db_views(
-        klass, name: str, is_glean: bool, channels: List[Dict[str, str]], db_views: dict
+        klass,
+        namespace: str,
+        is_glean: bool,
+        channels: List[Dict[str, str]],
+        db_views: dict,
     ) -> Iterator[PingView]:
         """Get Looker views for a namespace."""
         if (klass.allow_glean and not is_glean) or (not klass.allow_glean and is_glean):
@@ -47,12 +51,12 @@ class PingView(View):
                 views[view_id].append(table)
 
         for view_id, tables in views.items():
-            yield klass(view_id, tables)
+            yield klass(namespace, view_id, tables)
 
     @classmethod
-    def from_dict(klass, name: str, _dict: ViewDict) -> PingView:
+    def from_dict(klass, namespace: str, name: str, _dict: ViewDict) -> PingView:
         """Get a view from a name and dict definition."""
-        return klass(name, _dict["tables"])
+        return klass(namespace, name, _dict["tables"])
 
     def to_lookml(self, bq_client) -> List[dict]:
         """Generate LookML for this view."""

--- a/generator/views/table_view.py
+++ b/generator/views/table_view.py
@@ -14,13 +14,17 @@ class TableView(View):
 
     type: str = "table_view"
 
-    def __init__(self, name: str, tables: List[Dict[str, str]]):
+    def __init__(self, namespace: str, name: str, tables: List[Dict[str, str]]):
         """Create instance of a TableView."""
-        super().__init__(name, TableView.type, tables)
+        super().__init__(namespace, name, TableView.type, tables)
 
     @classmethod
     def from_db_views(
-        klass, app: str, is_glean: bool, channels: List[Dict[str, str]], db_views: dict
+        klass,
+        namespace: str,
+        is_glean: bool,
+        channels: List[Dict[str, str]],
+        db_views: dict,
     ) -> Iterator[TableView]:
         """Get Looker views for a namespace."""
         views = defaultdict(list)
@@ -39,12 +43,12 @@ class TableView(View):
                 views[view_id].append(table)
 
         for view_id, tables in views.items():
-            yield TableView(f"{view_id}_table", tables)
+            yield TableView(namespace, f"{view_id}_table", tables)
 
     @classmethod
-    def from_dict(klass, name: str, _dict: ViewDict) -> TableView:
+    def from_dict(klass, namespace: str, name: str, _dict: ViewDict) -> TableView:
         """Get a view from a name and dict definition."""
-        return TableView(name, _dict["tables"])
+        return TableView(namespace, name, _dict["tables"])
 
     def to_lookml(self, bq_client) -> List[dict]:
         """Generate LookML for this view."""

--- a/generator/views/view.py
+++ b/generator/views/view.py
@@ -19,11 +19,18 @@ class View(object):
     name: str
     view_type: str
     tables: List[Dict[str, str]]
+    namespace: str
 
     def __init__(
-        self, name: str, view_type: str, tables: List[Dict[str, str]], **kwargs
+        self,
+        namespace: str,
+        name: str,
+        view_type: str,
+        tables: List[Dict[str, str]],
+        **kwargs,
     ):
         """Create an instance of a view."""
+        self.namespace = namespace
         self.tables = tables
         self.name = name
         self.view_type = view_type
@@ -31,7 +38,7 @@ class View(object):
     @classmethod
     def from_db_views(
         klass,
-        name: str,
+        namespace: str,
         is_glean: bool,
         channels: List[Dict[str, str]],
         db_views: dict,
@@ -40,7 +47,7 @@ class View(object):
         raise NotImplementedError("Only implemented in subclass.")
 
     @classmethod
-    def from_dict(klass, name: str, _dict: ViewDict) -> View:
+    def from_dict(klass, namespace: str, name: str, _dict: ViewDict) -> View:
         """Get a view from a name and dict definition."""
         raise NotImplementedError("Only implemented in subclass.")
 

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -128,9 +128,12 @@ class MockClient:
                                 fields=[
                                     bigquery.schema.SchemaField(
                                         "test_counter", "INTEGER"
-                                    )
+                                    ),
+                                    bigquery.schema.SchemaField(
+                                        "glean_validation_metrics_ping_count", "INTEGER"
+                                    ),
                                 ],
-                            )
+                            ),
                         ],
                     ),
                 ],
@@ -414,17 +417,35 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                             "sql": "${client_info__client_id}",
                         },
                         {
-                            "name": "counter__test_counter",
+                            "name": "test_counter",
                             "type": "sum",
                             "sql": "${metrics__counter__test_counter}",
+                            "links": [
+                                {
+                                    "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
+                                    "label": "Glean Dictionary "
+                                    "reference for Test "
+                                    "Counter",
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/baseline/metrics/test_counter",  # noqa: E501
+                                }
+                            ],
                         },
                         {
-                            "name": "counter__test_counter_client_count",
+                            "name": "test_counter_client_count",
                             "type": "count_distinct",
                             "sql": (
                                 "case when ${metrics__counter__test_counter} > 0 then "
                                 "${client_info__client_id}"
                             ),
+                            "links": [
+                                {
+                                    "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
+                                    "label": "Glean Dictionary "
+                                    "reference for Test "
+                                    "Counter",
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/baseline/metrics/test_counter",  # noqa: E501
+                                }
+                            ],
                         },
                     ],
                 }
@@ -449,6 +470,20 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                             "sql": "${TABLE}.client_info.client_id",
                         },
                         {
+                            "group_item_label": "Glean Validation Metrics Ping Count",
+                            "group_label": "Metrics Counter",
+                            "name": "metrics__counter__glean_validation_metrics_ping_count",
+                            "sql": "${TABLE}.metrics.counter.glean_validation_metrics_ping_count",  # noqa: E501
+                            "type": "number",
+                            "links": [
+                                {
+                                    "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
+                                    "label": "Glean Dictionary reference for Glean Validation Metrics Ping Count",  # noqa: E501
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/glean_validation_metrics_ping_count",  # noqa: E501
+                                }
+                            ],
+                        },
+                        {
                             "group_item_label": "Test Counter",
                             "group_label": "Metrics Counter",
                             "name": "metrics__counter__test_counter",
@@ -457,9 +492,7 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                             "links": [
                                 {
                                     "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
-                                    "label": "Glean Dictionary "
-                                    "reference for Test "
-                                    "Counter",
+                                    "label": "Glean Dictionary reference for Test Counter",
                                     "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/test_counter",  # noqa: E501
                                 }
                             ],
@@ -472,17 +505,64 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                             "sql": "${client_info__client_id}",
                         },
                         {
-                            "name": "counter__test_counter",
+                            "name": "glean_validation_metrics_ping_count",
                             "type": "sum",
-                            "sql": "${metrics__counter__test_counter}",
+                            "sql": "${metrics__counter__glean_validation_metrics_ping_count}",  # noqa: E501
+                            "links": [
+                                {
+                                    "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
+                                    "label": "Glean Dictionary "
+                                    "reference for Glean Validation Metrics Ping Count",
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/glean_validation_metrics_ping_count",  # noqa: E501
+                                }
+                            ],
                         },
                         {
-                            "name": "counter__test_counter_client_count",
+                            "name": "glean_validation_metrics_ping_count_client_count",
+                            "type": "count_distinct",
+                            "sql": (
+                                "case when ${metrics__counter__glean_validation_metrics_ping_count} > 0 then "
+                                "${client_info__client_id}"
+                            ),
+                            "links": [
+                                {
+                                    "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
+                                    "label": "Glean Dictionary "
+                                    "reference for Glean Validation Metrics Ping Count",
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/glean_validation_metrics_ping_count",  # noqa: E501
+                                }
+                            ],
+                        },
+                        {
+                            "name": "test_counter",
+                            "type": "sum",
+                            "sql": "${metrics__counter__test_counter}",
+                            "links": [
+                                {
+                                    "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
+                                    "label": "Glean Dictionary "
+                                    "reference for Test "
+                                    "Counter",
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/test_counter",  # noqa: E501
+                                }
+                            ],
+                        },
+                        {
+                            "name": "test_counter_client_count",
                             "type": "count_distinct",
                             "sql": (
                                 "case when ${metrics__counter__test_counter} > 0 then "
                                 "${client_info__client_id}"
                             ),
+                            "links": [
+                                {
+                                    "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
+                                    "label": "Glean Dictionary "
+                                    "reference for Test "
+                                    "Counter",
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/test_counter",  # noqa: E501
+                                }
+                            ],
                         },
                     ],
                 }

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -100,7 +100,7 @@ class MockClient:
                     bigquery.schema.SchemaField("parsed_date", "DATE"),
                 ],
             )
-        if table_ref == "mozdata.fail.duplicate_measure":
+        if table_ref == "mozdata.fail.duplicate_client":
             return bigquery.Table(
                 table_ref,
                 schema=[
@@ -445,7 +445,7 @@ def test_duplicate_dimension(runner, glean_apps, tmp_path):
                 _lookml(open(namespaces), glean_apps, "looker-hub/")
 
 
-def test_duplicate_measure(runner, glean_apps, tmp_path):
+def test_duplicate_client_id(runner, glean_apps, tmp_path):
     namespaces = tmp_path / "namespaces.yaml"
     namespaces.write_text(
         dedent(
@@ -458,7 +458,7 @@ def test_duplicate_measure(runner, glean_apps, tmp_path):
                   type: ping_view
                   tables:
                   - channel: release
-                    table: mozdata.fail.duplicate_measure
+                    table: mozdata.fail.duplicate_client
             """
         )
     )

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -307,7 +307,7 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                                     "label": "Glean Dictionary "
                                     "reference for Test "
                                     "Counter",
-                                    "url": "https://dictionary.telemetry.mozilla.org/apps/baseline/metrics/test_counter",  # noqa: E501
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/test_counter",  # noqa: E501
                                 }
                             ],
                         },
@@ -426,7 +426,7 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                                     "label": "Glean Dictionary "
                                     "reference for Test "
                                     "Counter",
-                                    "url": "https://dictionary.telemetry.mozilla.org/apps/baseline/metrics/test_counter",  # noqa: E501
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/test_counter",  # noqa: E501
                                 }
                             ],
                         },
@@ -443,7 +443,7 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                                     "label": "Glean Dictionary "
                                     "reference for Test "
                                     "Counter",
-                                    "url": "https://dictionary.telemetry.mozilla.org/apps/baseline/metrics/test_counter",  # noqa: E501
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/test_counter",  # noqa: E501
                                 }
                             ],
                         },
@@ -479,7 +479,7 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                                 {
                                     "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
                                     "label": "Glean Dictionary reference for Glean Validation Metrics Ping Count",  # noqa: E501
-                                    "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/glean_validation_metrics_ping_count",  # noqa: E501
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/glean_validation_metrics_ping_count",  # noqa: E501
                                 }
                             ],
                         },
@@ -493,7 +493,7 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                                 {
                                     "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
                                     "label": "Glean Dictionary reference for Test Counter",
-                                    "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/test_counter",  # noqa: E501
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/test_counter",  # noqa: E501
                                 }
                             ],
                         },
@@ -513,7 +513,7 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                                     "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
                                     "label": "Glean Dictionary "
                                     "reference for Glean Validation Metrics Ping Count",
-                                    "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/glean_validation_metrics_ping_count",  # noqa: E501
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/glean_validation_metrics_ping_count",  # noqa: E501
                                 }
                             ],
                         },
@@ -529,7 +529,7 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                                     "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
                                     "label": "Glean Dictionary "
                                     "reference for Glean Validation Metrics Ping Count",
-                                    "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/glean_validation_metrics_ping_count",  # noqa: E501
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/glean_validation_metrics_ping_count",  # noqa: E501
                                 }
                             ],
                         },
@@ -543,7 +543,7 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                                     "label": "Glean Dictionary "
                                     "reference for Test "
                                     "Counter",
-                                    "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/test_counter",  # noqa: E501
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/test_counter",  # noqa: E501
                                 }
                             ],
                         },
@@ -560,7 +560,7 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                                     "label": "Glean Dictionary "
                                     "reference for Test "
                                     "Counter",
-                                    "url": "https://dictionary.telemetry.mozilla.org/apps/metrics/metrics/test_counter",  # noqa: E501
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/test_counter",  # noqa: E501
                                 }
                             ],
                         },

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -80,6 +80,21 @@ class MockClient:
                             ),
                         ],
                     ),
+                    bigquery.schema.SchemaField(
+                        "metrics",
+                        "RECORD",
+                        fields=[
+                            bigquery.schema.SchemaField(
+                                "counter",
+                                "RECORD",
+                                fields=[
+                                    bigquery.schema.SchemaField(
+                                        "test_counter", "INTEGER"
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
                     bigquery.schema.SchemaField("parsed_timestamp", "TIMESTAMP"),
                     bigquery.schema.SchemaField("submission_timestamp", "TIMESTAMP"),
                     bigquery.schema.SchemaField("submission_date", "DATE"),
@@ -278,6 +293,22 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                             "type": "string",
                         },
                         {
+                            "group_item_label": "Test Counter",
+                            "group_label": "Metrics Counter",
+                            "name": "metrics__counter__test_counter",
+                            "sql": "${TABLE}.metrics.counter.test_counter",
+                            "type": "number",
+                            "links": [
+                                {
+                                    "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
+                                    "label": "Glean Dictionary "
+                                    "reference for Test "
+                                    "Counter",
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/baseline/metrics/test_counter",  # noqa: E501
+                                }
+                            ],
+                        },
+                        {
                             "name": "test_bignumeric",
                             "sql": "${TABLE}.test_bignumeric",
                             "type": "string",
@@ -381,6 +412,19 @@ def test_lookml_actual(runner, glean_apps, tmp_path):
                             "name": "clients",
                             "type": "count_distinct",
                             "sql": "${client_info__client_id}",
+                        },
+                        {
+                            "name": "counter__test_counter",
+                            "type": "sum",
+                            "sql": "${metrics__counter__test_counter}",
+                        },
+                        {
+                            "name": "counter__test_counter_client_count",
+                            "type": "count_distinct",
+                            "sql": (
+                                "case when ${metrics__counter__test_counter} > 0 then "
+                                "${client_info__client_id}"
+                            ),
                         },
                     ],
                 }

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -245,24 +245,27 @@ def test_get_glean_apps(app_listings_uri, glean_apps):
 def test_get_looker_views(glean_apps, generated_sql_uri):
     db_views = _get_db_views(generated_sql_uri)
     actual = _get_looker_views(glean_apps[0], db_views)
+    namespace = glean_apps[0]["name"]
     expected = [
         GleanPingView(
+            namespace,
             "baseline",
             [
                 {"channel": "release", "table": "mozdata.glean_app.baseline"},
                 {"channel": "beta", "table": "mozdata.glean_app_beta.baseline"},
             ],
-            app=glean_apps[0],
         ),
         GrowthAccountingView(
+            namespace,
             [
                 {
                     "channel": "release",
                     "table": "mozdata.glean_app.baseline_clients_daily",
                 }
-            ]
+            ],
         ),
         TableView(
+            namespace,
             "baseline_clients_daily_table",
             [
                 {
@@ -276,6 +279,7 @@ def test_get_looker_views(glean_apps, generated_sql_uri):
             ],
         ),
         TableView(
+            namespace,
             "baseline_table",
             [
                 {"table": "mozdata.glean_app.baseline", "channel": "release"},
@@ -283,6 +287,7 @@ def test_get_looker_views(glean_apps, generated_sql_uri):
             ],
         ),
         TableView(
+            namespace,
             "baseline_clients_last_seen_table",
             [
                 {


### PR DESCRIPTION
This adds some measures for counters in the glean pings. It looks like there will probably more general ways of handling glean pings, but this is a start.

Here's an example push: https://github.com/mozilla/looker-hub/commit/68cd4f805e068d64f1a841b7a280eb58864fb54a

