### PR TITLE
Expose Firefox iOS and add `TableView`

### DIFF
--- a/GENERATION_DISALLOW_LIST
+++ b/GENERATION_DISALLOW_LIST
@@ -1,3 +1,8 @@
 firefox_ios/views/baseline.view.lkml
 firefox_ios/views/events.view.lkml
 firefox_ios/views/metrics.view.lkml
+firefox_ios/views/growth_accounting.view.lkml
+firefox_ios/explores/events.explore.lkml
+firefox_ios/explores/growth_accounting.explore.lkml
+firefox_ios/explores/metrics.explore.lkml
+firefox_ios/explores/baseline.explore.lkml

--- a/bin/generate
+++ b/bin/generate
@@ -165,7 +165,7 @@ function generate_hub_commit() {
   cd $HUB_DIR
 
   # Keep files in GENERATION_DISALLOW_LIST unchanged.
-  cat $GENERATION_DISALLOW_LIST | xargs -I % git checkout %
+  cat $GENERATION_DISALLOW_LIST | xargs -I % sh -c "git checkout % || rm %"
 
   check_files_and_commit
 

--- a/generator/views/__init__.py
+++ b/generator/views/__init__.py
@@ -1,9 +1,11 @@
 """All available Looker views."""
 from .growth_accounting_view import GrowthAccountingView
 from .ping_view import PingView
+from .table_view import TableView
 from .view import View, ViewDict  # noqa: F401
 
 VIEW_TYPES = {
     PingView.type: PingView,
     GrowthAccountingView.type: GrowthAccountingView,
+    TableView.type: TableView,
 }

--- a/generator/views/table_view.py
+++ b/generator/views/table_view.py
@@ -1,0 +1,89 @@
+"""Class to describe a Ping View."""
+from __future__ import annotations
+
+from collections import defaultdict
+from itertools import filterfalse
+from typing import Any, Dict, Iterator, List
+
+from . import lookml_utils
+from .view import OMIT_VIEWS, View, ViewDict
+
+
+class TableView(View):
+    """A view on any table."""
+
+    type: str = "table_view"
+
+    def __init__(self, name: str, tables: List[Dict[str, str]]):
+        """Create instance of a TableView."""
+        super().__init__(name, TableView.type, tables)
+
+    @classmethod
+    def from_db_views(
+        klass, app: str, channels: List[Dict[str, str]], db_views: dict
+    ) -> Iterator[TableView]:
+        """Get Looker views for a namespace."""
+        views = defaultdict(list)
+        for channel in channels:
+            dataset = channel["dataset"]
+
+            for view_id, references in db_views[dataset].items():
+                if view_id in OMIT_VIEWS:
+                    continue
+
+                table: Dict[str, str] = {"table": f"mozdata.{dataset}.{view_id}"}
+
+                if "channel" in channel:
+                    table["channel"] = channel["channel"]
+
+                views[view_id].append(table)
+
+        for view_id, tables in views.items():
+            yield TableView(f"{view_id}_table", tables)
+
+    @classmethod
+    def from_dict(klass, name: str, _dict: ViewDict) -> TableView:
+        """Get a view from a name and dict definition."""
+        return TableView(name, _dict["tables"])
+
+    def to_lookml(self, bq_client) -> List[dict]:
+        """Generate LookML for this view."""
+        view_defn: Dict[str, Any] = {"name": self.name}
+
+        # use schema for the table where channel=="release" or the first one
+        table = next(
+            (table for table in self.tables if table.get("channel") == "release"),
+            self.tables[0],
+        )["table"]
+
+        # add dimensions and dimension groups
+        dimensions = lookml_utils._generate_dimensions(bq_client, table)
+        view_defn["dimensions"] = list(
+            filterfalse(lookml_utils._is_dimension_group, dimensions)
+        )
+        view_defn["dimension_groups"] = list(
+            filter(lookml_utils._is_dimension_group, dimensions)
+        )
+
+        # Table views have no measures
+
+        # parameterize table name
+        if len(self.tables) > 1:
+            view_defn["parameters"] = [
+                {
+                    "name": "channel",
+                    "type": "unquoted",
+                    "allowed_values": [
+                        {
+                            "label": table["channel"].title(),
+                            "value": table["table"],
+                        }
+                        for table in self.tables
+                    ],
+                }
+            ]
+            view_defn["sql_table_name"] = "`{% parameter channel %}`"
+        else:
+            view_defn["sql_table_name"] = f"`{table}`"
+
+        return [view_defn]

--- a/namespace_allowlist.yaml
+++ b/namespace_allowlist.yaml
@@ -1,3 +1,4 @@
 ---
 - burnham
 - duet
+- firefox_ios


### PR DESCRIPTION
A TableView simply exposes a raw table, with no measures.

Eventually we will import this instead of re-generating
all dimensions multiple times.

@wlach I think this may conflict with your changes. Take a look and let me know, I'd rather not block you, and can rebase on yours once we merge that.