### PR TITLE
Allow for special chars in filter expressions

### DIFF
--- a/generator/explores/ping_explore.py
+++ b/generator/explores/ping_explore.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Iterator, List
 
 from ..views import PingView, View
+from ..views.lookml_utils import escape_filter_expr
 from . import Explore
 
 
@@ -33,7 +34,7 @@ class PingExplore(Explore):
                 allowed_values[0],
             )["value"]
 
-            filters.append({"channel": default_value})
+            filters.append({"channel": escape_filter_expr(default_value)})
 
         return {
             "name": self.name,

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -102,3 +102,8 @@ def _generate_dimensions(client: bigquery.Client, table: str) -> List[Dict[str, 
 def _is_dimension_group(dimension: dict):
     """Determine if a dimension is actually a dimension group."""
     return "timeframes" in dimension or "intervals" in dimension
+
+
+def escape_filter_expr(expr: str) -> str:
+    """Escape filter expression for special Looker chars."""
+    return re.sub(r'((?:^-)|["_%,^])', r"^\1", expr, count=0)

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -407,7 +407,7 @@ def test_lookml_actual(runner, tmp_path):
                     "always_filter": {
                         "filters": [
                             {"submission_date": "28 days"},
-                            {"channel": "mozdata.glean_app.baseline"},
+                            {"channel": "mozdata.glean^_app.baseline"},
                         ]
                     },
                 }

--- a/tests/test_lookml_utils.py
+++ b/tests/test_lookml_utils.py
@@ -1,0 +1,16 @@
+from generator.views.lookml_utils import escape_filter_expr
+
+
+def test_escape_char():
+    expr = "a_b"
+    assert escape_filter_expr(expr) == "a^_b"
+
+
+def test_escape_multi_char():
+    expr = 'a_b%c,d"f^g'
+    assert escape_filter_expr(expr) == 'a^_b^%c^,d^"f^^g'
+
+
+def test_escape_leading_char():
+    expr = "-a-b"
+    assert escape_filter_expr(expr) == "^-a-b"


### PR DESCRIPTION
This hasn't caught us yet, but e.g. `_` is a special char, so when we expose channels they will fail (burnham has no channels so we didn't see anything.)