### PR TITLE
Fix spurious comma in growth accounting measure

### DIFF
--- a/generator/views/growth_accounting_view.py
+++ b/generator/views/growth_accounting_view.py
@@ -149,7 +149,7 @@ class GrowthAccountingView(View):
             "name": "established_user_retention_rate",
             "type": "number",
             "sql": (
-                "SAFE_DIVIDE(,"
+                "SAFE_DIVIDE("
                 "${established_users_returning},"
                 "(${established_users_returning} + ${established_users_churned_count})"
                 ")"


### PR DESCRIPTION
This is something that could be caught if we integrated with [spectacles](https://www.spectacles.dev/).