### PR TITLE
Don't nest dimension groups

### DIFF
--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -68,8 +68,8 @@ def _get_dimension(path: Tuple[str, ...], field_type: str, mode: str) -> Dict[st
                 # Dimension groups should not be nested, see issue #82
                 result["label"] = f"{group_label}: {group_item_label}"
         elif len(path) > 1:
-            result["group_label"] = " ".join(path[:-1]).replace("_", " ").title()
-            result["group_item_label"] = path[-1].replace("_", " ").title()
+            result["group_label"] = group_label
+            result["group_item_label"] = group_item_label
         if path in MAP_LAYER_NAMES:
             result["map_layer_name"] = MAP_LAYER_NAMES[path]
     result["name"] = "__".join(name)

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -39,6 +39,11 @@ def _get_dimension(path: Tuple[str, ...], field_type: str, mode: str) -> Dict[st
         result["hidden"] = "yes"
     else:
         result["type"] = BIGQUERY_TYPE_TO_DIMENSION_TYPE[field_type]
+
+        group_label, group_item_label = None, None
+        if len(path) > 1:
+            group_label = " ".join(path[:-1]).replace("_", " ").title()
+            group_item_label = path[-1].replace("_", " ").title()
         if result["type"] == "time":
             # Remove _{type} suffix from the last path element for dimension group
             # names For example submission_date and submission_timestamp become
@@ -59,7 +64,10 @@ def _get_dimension(path: Tuple[str, ...], field_type: str, mode: str) -> Dict[st
                 result["timeframes"].remove("time")
                 result["convert_tz"] = "no"
                 result["datatype"] = "date"
-        if len(path) > 1:
+            if group_label and group_item_label:
+                # Dimension groups should not be nested, see issue #82
+                result["label"] = f"{group_label}: {group_item_label}"
+        elif len(path) > 1:
             result["group_label"] = " ".join(path[:-1]).replace("_", " ").title()
             result["group_item_label"] = path[-1].replace("_", " ").title()
         if path in MAP_LAYER_NAMES:

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -677,8 +677,7 @@ def test_lookml_actual(mock_glean_ping, runner, glean_apps, tmp_path, msg_glean_
                             "name": "client_info__parsed_first_run",
                             "convert_tz": "no",
                             "datatype": "date",
-                            "group_item_label": "Parsed First Run Date",
-                            "group_label": "Client Info",
+                            "label": "Client Info: Parsed First Run Date",
                             "sql": "${TABLE}.client_info.parsed_first_run_date",
                             "timeframes": [
                                 "raw",
@@ -692,8 +691,7 @@ def test_lookml_actual(mock_glean_ping, runner, glean_apps, tmp_path, msg_glean_
                         },
                         {
                             "name": "metadata__header__parsed",
-                            "group_item_label": "Parsed Date",
-                            "group_label": "Metadata Header",
+                            "label": "Metadata Header: Parsed Date",
                             "sql": "${TABLE}.metadata.header.parsed_date",
                             "timeframes": [
                                 "raw",


### PR DESCRIPTION
Fixes #82. Instead shows a label that says e.g. `Client Info: Parsed Start Date`.