### PR TITLE
Use correct naming for model sets

### DIFF
--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -86,8 +86,8 @@ def configure_model(sdk: looker_sdk.methods.Looker31SDK, model_name: str):
         )
     )
 
-    for model_name in MODEL_SETS_BY_INSTANCE[instance]:
-        model_sets = sdk.search_model_sets(name=model_name)
+    for model_set_name in MODEL_SETS_BY_INSTANCE[instance]:
+        model_sets = sdk.search_model_sets(name=model_set_name)
         if len(model_sets) != 1:
             raise click.ClickException("Error: Found more than one matching model set")
 

--- a/tests/test_spoke.py
+++ b/tests/test_spoke.py
@@ -102,7 +102,7 @@ def test_generate_model(looker_sdk, namespaces, tmp_path):
     sdk = looker_sdk.init31()
     sdk.search_model_sets.side_effect = [
         [Mock(models=["model"], id=1)],
-        [Mock(models=["model2"], id=2)],
+        [Mock(models=["model", "model2"], id=2)],
     ]
     sdk.lookml_model.side_effect = _looker_sdk.error.SDKError
     looker_sdk.error = Mock(SDKError=_looker_sdk.error.SDKError)
@@ -124,6 +124,12 @@ def test_generate_model(looker_sdk, namespaces, tmp_path):
     }
     actual = lkml.load((tmp_path / "glean-app" / "glean-app.model.lkml").read_text())
     assert expected == actual
+
+    looker_sdk.models.WriteModelSet.assert_any_call(models=["model", "glean-app"])
+    looker_sdk.models.WriteModelSet.assert_any_call(
+        models=["model", "model2", "glean-app"]
+    )
+    assert looker_sdk.models.WriteModelSet.call_count == 2
 
     sdk.update_model_set.assert_any_call(1, write_model)
     sdk.update_model_set.assert_any_call(2, write_model)


### PR DESCRIPTION
Previously, we were not updating the model sets correctly -
because of that, we wouldn't see models configured properly
in prod. This should add the actual model name to the set of
models that are part of each model set.