### PR TITLE
Add transitive google deps for dependabot updates

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,8 @@
 PyYAML==5.4.1
 click==8.0.1
+google-api-core==1.28.0  # transitive dep that needs dependabot updates
 google-cloud-bigquery==2.17.0
+googleapis-common-protos==1.53.0  # transitive dep that needs dependabot updates
 lkml==1.1.0
 looker-sdk==21.6.0
 mozilla-schema-generator==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -116,6 +116,7 @@ google-api-core[grpc]==1.28.0 \
     --hash=sha256:02646803bd728e12dd1f45ee1dcc31c12614c9a1ac451b9a1ce26aa65df9b957 \
     --hash=sha256:a658a4e367511a444c7daf2c58855ff6fd7f7d138c154e5b17186c1f8154c8cb
     # via
+    #   -r requirements.in
     #   google-cloud-bigquery
     #   google-cloud-core
 google-auth==1.30.0 \
@@ -170,7 +171,9 @@ google-resumable-media==1.2.0 \
 googleapis-common-protos==1.53.0 \
     --hash=sha256:a88ee8903aa0a81f6c3cec2d5cf62d3c8aa67c06439b0496b49048fb1854ebf4 \
     --hash=sha256:f6d561ab8fb16b30020b940e2dd01cd80082f4762fa9f3ee670f4419b4b8dbd0
-    # via google-api-core
+    # via
+    #   -r requirements.in
+    #   google-api-core
 grpcio==1.37.1 \
     --hash=sha256:025fa7dffb0cf724070cfcbe2ff600a18b0cf84642ede5c92f2717162e2a8c95 \
     --hash=sha256:0b8817acef140cb9a3543208c13282d3bf4bb0103e930ddbb779677604085ada \


### PR DESCRIPTION
workaround for pypa/pip#9644

similar to https://github.com/mozilla/bigquery-etl/pull/2064