### PR TITLE
Generate descriptions for Glean Ping explores (fixes #106)

### DIFF
--- a/generator/explores/client_counts_explore.py
+++ b/generator/explores/client_counts_explore.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Optional
 
 from ..views import View
 from . import Explore
@@ -37,7 +37,7 @@ class ClientCountsExplore(Explore):
         },
     ]
 
-    def _to_lookml(self) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         return [
             {
@@ -61,7 +61,8 @@ class ClientCountsExplore(Explore):
         for view in views:
             if view.name == "client_counts":
                 yield ClientCountsExplore(
-                    "client_counts",
+                    view.name,
+                    view.namespace,
                     {
                         "base_view": "client_counts",
                         "extended_view": "baseline_clients_daily_table",
@@ -69,6 +70,8 @@ class ClientCountsExplore(Explore):
                 )
 
     @staticmethod
-    def from_dict(name: str, defn: dict, views_path: Path) -> ClientCountsExplore:
+    def from_dict(
+        name: str, namespace: str, defn: dict, views_path: Path
+    ) -> ClientCountsExplore:
         """Get an instance of this explore from a dictionary definition."""
-        return ClientCountsExplore(name, defn["views"], views_path)
+        return ClientCountsExplore(name, namespace, defn["views"], views_path)

--- a/generator/explores/client_counts_explore.py
+++ b/generator/explores/client_counts_explore.py
@@ -62,7 +62,6 @@ class ClientCountsExplore(Explore):
             if view.name == "client_counts":
                 yield ClientCountsExplore(
                     view.name,
-                    view.namespace,
                     {
                         "base_view": "client_counts",
                         "extended_view": "baseline_clients_daily_table",
@@ -70,8 +69,6 @@ class ClientCountsExplore(Explore):
                 )
 
     @staticmethod
-    def from_dict(
-        name: str, namespace: str, defn: dict, views_path: Path
-    ) -> ClientCountsExplore:
+    def from_dict(name: str, defn: dict, views_path: Path) -> ClientCountsExplore:
         """Get an instance of this explore from a dictionary definition."""
-        return ClientCountsExplore(name, namespace, defn["views"], views_path)
+        return ClientCountsExplore(name, defn["views"], views_path)

--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -15,6 +15,7 @@ class Explore:
     """A generic explore."""
 
     name: str
+    namespace: str
     views: Dict[str, str]
     views_path: Optional[Path] = None
     type: str = field(init=False)
@@ -23,7 +24,7 @@ class Explore:
         """Explore instance represented as a dict."""
         return {self.name: {"type": self.type, "views": self.views}}
 
-    def to_lookml(self) -> List[Dict[str, Any]]:
+    def to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """
         Generate LookML for this explore.
 
@@ -58,13 +59,13 @@ class Explore:
                 ] = f"${{{base_view_name}.submission_date}} >= '2010-01-01'"
 
         # We only update the first returned explore
-        new_lookml = self._to_lookml()
+        new_lookml = self._to_lookml(v1_name)
         base_lookml.update(new_lookml[0])
         new_lookml[0] = base_lookml
 
         return new_lookml
 
-    def _to_lookml(self) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         raise NotImplementedError("Only implemented in subclasses")
 
     def get_dependent_views(self) -> List[str]:
@@ -76,7 +77,7 @@ class Explore:
         ]
 
     @staticmethod
-    def from_dict(name: str, defn: dict, views_path: Path) -> Explore:
+    def from_dict(name: str, namespace: str, defn: dict, views_path: Path) -> Explore:
         """Get an instance of an explore from a namespace definition."""
         raise NotImplementedError("Only implemented in subclasses")
 

--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -15,7 +15,6 @@ class Explore:
     """A generic explore."""
 
     name: str
-    namespace: str
     views: Dict[str, str]
     views_path: Optional[Path] = None
     type: str = field(init=False)
@@ -77,7 +76,7 @@ class Explore:
         ]
 
     @staticmethod
-    def from_dict(name: str, namespace: str, defn: dict, views_path: Path) -> Explore:
+    def from_dict(name: str, defn: dict, views_path: Path) -> Explore:
         """Get an instance of an explore from a namespace definition."""
         raise NotImplementedError("Only implemented in subclasses")
 

--- a/generator/explores/funnel_analysis_explore.py
+++ b/generator/explores/funnel_analysis_explore.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Optional
 
 from ..views import View
 from . import Explore
@@ -25,15 +25,18 @@ class FunnelAnalysisExplore(Explore):
             if view.name == "funnel_analysis":
                 yield FunnelAnalysisExplore(
                     "funnel_analysis",
+                    view.namespace,
                     {"base_view": view.name},
                 )
 
     @staticmethod
-    def from_dict(name: str, defn: dict, views_path: Path) -> FunnelAnalysisExplore:
+    def from_dict(
+        name: str, namespace: str, defn: dict, views_path: Path
+    ) -> FunnelAnalysisExplore:
         """Get an instance of this explore from a dictionary definition."""
-        return FunnelAnalysisExplore(name, defn["views"], views_path)
+        return FunnelAnalysisExplore(name, namespace, defn["views"], views_path)
 
-    def _to_lookml(self) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         view_lookml = self.get_view_lookml("funnel_analysis")
         views = view_lookml["views"]
         n_events = len([d for d in views if d["name"].startswith("step_")])

--- a/generator/explores/funnel_analysis_explore.py
+++ b/generator/explores/funnel_analysis_explore.py
@@ -25,16 +25,13 @@ class FunnelAnalysisExplore(Explore):
             if view.name == "funnel_analysis":
                 yield FunnelAnalysisExplore(
                     "funnel_analysis",
-                    view.namespace,
                     {"base_view": view.name},
                 )
 
     @staticmethod
-    def from_dict(
-        name: str, namespace: str, defn: dict, views_path: Path
-    ) -> FunnelAnalysisExplore:
+    def from_dict(name: str, defn: dict, views_path: Path) -> FunnelAnalysisExplore:
         """Get an instance of this explore from a dictionary definition."""
-        return FunnelAnalysisExplore(name, namespace, defn["views"], views_path)
+        return FunnelAnalysisExplore(name, defn["views"], views_path)
 
     def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         view_lookml = self.get_view_lookml("funnel_analysis")

--- a/generator/explores/glean_ping_explore.py
+++ b/generator/explores/glean_ping_explore.py
@@ -24,7 +24,7 @@ class GleanPingExplore(PingExplore):
         ping_descriptions = {
             k.replace("-", "_"): v for k, v in glean_app.get_ping_descriptions().items()
         }
-        ping_description = ping_descriptions[self.name]
+        ping_description = " ".join(ping_descriptions[self.name].split())
         lookml = super()._to_lookml(v1_name)
         lookml[0][
             "description"

--- a/generator/explores/glean_ping_explore.py
+++ b/generator/explores/glean_ping_explore.py
@@ -24,7 +24,9 @@ class GleanPingExplore(PingExplore):
         ping_descriptions = {
             k.replace("-", "_"): v for k, v in glean_app.get_ping_descriptions().items()
         }
+        # collapse whitespace in the description so the lookml looks a little better
         ping_description = " ".join(ping_descriptions[self.name].split())
+        # insert the description in
         lookml = super()._to_lookml(v1_name)
         lookml[0][
             "description"

--- a/generator/explores/glean_ping_explore.py
+++ b/generator/explores/glean_ping_explore.py
@@ -38,13 +38,9 @@ class GleanPingExplore(PingExplore):
         """Generate all possible GleanPingExplores from the views."""
         for view in views:
             if view.view_type == GleanPingView.type:
-                yield GleanPingExplore(
-                    view.name, view.namespace, {"base_view": view.name}
-                )
+                yield GleanPingExplore(view.name, {"base_view": view.name})
 
     @staticmethod
-    def from_dict(
-        name: str, namespace: str, defn: dict, views_path: Path
-    ) -> GleanPingExplore:
+    def from_dict(name: str, defn: dict, views_path: Path) -> GleanPingExplore:
         """Get an instance of this explore from a name and dictionary definition."""
-        return GleanPingExplore(name, namespace, defn["views"], views_path)
+        return GleanPingExplore(name, defn["views"], views_path)

--- a/generator/explores/glean_ping_explore.py
+++ b/generator/explores/glean_ping_explore.py
@@ -1,5 +1,10 @@
 """Glean Ping explore type."""
-from typing import Iterator, List
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+from mozilla_schema_generator.glean_ping import GleanPing
 
 from ..views import GleanPingView, View
 from .ping_explore import PingExplore
@@ -10,9 +15,29 @@ class GleanPingExplore(PingExplore):
 
     type: str = "glean_ping_explore"
 
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+        """Generate LookML to represent this explore."""
+        repo = next((r for r in GleanPing.get_repos() if r["name"] == v1_name))
+        glean_app = GleanPing(repo)
+        ping_description = glean_app.get_ping_descriptions()[self.name]
+        lookml = super()._to_lookml(v1_name)
+        lookml[0][
+            "description"
+        ] = f"Explore for the {self.name} ping. {ping_description}"
+        return lookml
+
     @staticmethod
     def from_views(views: List[View]) -> Iterator[PingExplore]:
         """Generate all possible GleanPingExplores from the views."""
         for view in views:
             if view.view_type == GleanPingView.type:
-                yield GleanPingExplore(view.name, {"base_view": view.name})
+                yield GleanPingExplore(
+                    view.name, view.namespace, {"base_view": view.name}
+                )
+
+    @staticmethod
+    def from_dict(
+        name: str, namespace: str, defn: dict, views_path: Path
+    ) -> GleanPingExplore:
+        """Get an instance of this explore from a name and dictionary definition."""
+        return GleanPingExplore(name, namespace, defn["views"], views_path)

--- a/generator/explores/glean_ping_explore.py
+++ b/generator/explores/glean_ping_explore.py
@@ -19,7 +19,12 @@ class GleanPingExplore(PingExplore):
         """Generate LookML to represent this explore."""
         repo = next((r for r in GleanPing.get_repos() if r["name"] == v1_name))
         glean_app = GleanPing(repo)
-        ping_description = glean_app.get_ping_descriptions()[self.name]
+        # convert ping description indexes to snake case, as we already have
+        # for the explore name
+        ping_descriptions = {
+            k.replace("-", "_"): v for k, v in glean_app.get_ping_descriptions().items()
+        }
+        ping_description = ping_descriptions[self.name]
         lookml = super()._to_lookml(v1_name)
         lookml[0][
             "description"

--- a/generator/explores/growth_accounting_explore.py
+++ b/generator/explores/growth_accounting_explore.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Optional
 
 from ..views import View
 from . import Explore
@@ -13,7 +13,7 @@ class GrowthAccountingExplore(Explore):
 
     type: str = "growth_accounting_explore"
 
-    def _to_lookml(self) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         return [
             {
@@ -32,11 +32,14 @@ class GrowthAccountingExplore(Explore):
         for view in views:
             if view.name == "growth_accounting":
                 yield GrowthAccountingExplore(
-                    "growth_accounting",
+                    view.name,
+                    view.namespace,
                     {"base_view": "growth_accounting"},
                 )
 
     @staticmethod
-    def from_dict(name: str, defn: dict, views_path: Path) -> GrowthAccountingExplore:
+    def from_dict(
+        name: str, namespace: str, defn: dict, views_path: Path
+    ) -> GrowthAccountingExplore:
         """Get an instance of this explore from a dictionary definition."""
-        return GrowthAccountingExplore(name, defn["views"], views_path)
+        return GrowthAccountingExplore(name, namespace, defn["views"], views_path)

--- a/generator/explores/growth_accounting_explore.py
+++ b/generator/explores/growth_accounting_explore.py
@@ -33,13 +33,10 @@ class GrowthAccountingExplore(Explore):
             if view.name == "growth_accounting":
                 yield GrowthAccountingExplore(
                     view.name,
-                    view.namespace,
                     {"base_view": "growth_accounting"},
                 )
 
     @staticmethod
-    def from_dict(
-        name: str, namespace: str, defn: dict, views_path: Path
-    ) -> GrowthAccountingExplore:
+    def from_dict(name: str, defn: dict, views_path: Path) -> GrowthAccountingExplore:
         """Get an instance of this explore from a dictionary definition."""
-        return GrowthAccountingExplore(name, namespace, defn["views"], views_path)
+        return GrowthAccountingExplore(name, defn["views"], views_path)

--- a/generator/explores/ping_explore.py
+++ b/generator/explores/ping_explore.py
@@ -30,11 +30,9 @@ class PingExplore(Explore):
         """Generate all possible PingExplores from the views."""
         for view in views:
             if view.view_type == PingView.type:
-                yield PingExplore(view.name, view.namespace, {"base_view": view.name})
+                yield PingExplore(view.name, {"base_view": view.name})
 
     @staticmethod
-    def from_dict(
-        name: str, namespace: str, defn: dict, views_path: Path
-    ) -> PingExplore:
+    def from_dict(name: str, defn: dict, views_path: Path) -> PingExplore:
         """Get an instance of this explore from a name and dictionary definition."""
-        return PingExplore(name, namespace, defn["views"], views_path)
+        return PingExplore(name, defn["views"], views_path)

--- a/generator/explores/ping_explore.py
+++ b/generator/explores/ping_explore.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Optional
 
 from ..views import PingView, View
 from . import Explore
@@ -13,7 +13,7 @@ class PingExplore(Explore):
 
     type: str = "ping_explore"
 
-    def _to_lookml(self) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         return [
             {
@@ -30,9 +30,11 @@ class PingExplore(Explore):
         """Generate all possible PingExplores from the views."""
         for view in views:
             if view.view_type == PingView.type:
-                yield PingExplore(view.name, {"base_view": view.name})
+                yield PingExplore(view.name, view.namespace, {"base_view": view.name})
 
     @staticmethod
-    def from_dict(name: str, defn: dict, views_path: Path) -> PingExplore:
+    def from_dict(
+        name: str, namespace: str, defn: dict, views_path: Path
+    ) -> PingExplore:
         """Get an instance of this explore from a name and dictionary definition."""
-        return PingExplore(name, defn["views"], views_path)
+        return PingExplore(name, namespace, defn["views"], views_path)

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -38,9 +38,7 @@ def _generate_explores(
 ) -> Iterable[Path]:
     for explore_name, defn in explores.items():
         logging.info(f"Generating lookml for explore {explore_name} in {namespace}")
-        explore = EXPLORE_TYPES[defn["type"]].from_dict(
-            explore_name, namespace, defn, views_dir
-        )
+        explore = EXPLORE_TYPES[defn["type"]].from_dict(explore_name, defn, views_dir)
         file_lookml = {
             # Looker validates all included files,
             # so if we're not explicit about files here, validation takes

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -27,11 +27,18 @@ def _generate_views(
 
 
 def _generate_explores(
-    client, out_dir: Path, namespace: str, explores: dict, views_dir: Path
+    client,
+    out_dir: Path,
+    namespace: str,
+    explores: dict,
+    views_dir: Path,
+    v1_name: Optional[str],
 ) -> Iterable[Path]:
     for explore_name, defn in explores.items():
         logging.info(f"Generating lookml for explore {explore_name} in {namespace}")
-        explore = EXPLORE_TYPES[defn["type"]].from_dict(explore_name, defn, views_dir)
+        explore = EXPLORE_TYPES[defn["type"]].from_dict(
+            explore_name, namespace, defn, views_dir
+        )
         file_lookml = {
             # Looker validates all included files,
             # so if we're not explicit about files here, validation takes
@@ -40,7 +47,7 @@ def _generate_explores(
                 f"/looker-hub/{namespace}/views/{view}.view.lkml"
                 for view in explore.get_dependent_views()
             ],
-            "explores": explore.to_lookml(),
+            "explores": explore.to_lookml(v1_name),
         }
         path = out_dir / (explore_name + ".explore.lkml")
         path.write_text(lkml_update.dump(file_lookml))
@@ -89,7 +96,7 @@ def _lookml(namespaces, glean_apps, target_dir):
         explores = lookml_objects.get("explores", {})
         logging.info("  Generating explores")
         for explore_path in _generate_explores(
-            client, explore_dir, namespace, explores, view_dir
+            client, explore_dir, namespace, explores, view_dir, v1_name
         ):
             logging.info(f"    ...Generating {explore_path}")
 

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -32,7 +32,9 @@ def _generate_explores(
     namespace: str,
     explores: dict,
     views_dir: Path,
-    v1_name: Optional[str],
+    v1_name: Optional[
+        str
+    ],  # v1_name for Glean explores: see: https://mozilla.github.io/probe-scraper/#tag/library
 ) -> Iterable[Path]:
     for explore_name, defn in explores.items():
         logging.info(f"Generating lookml for explore {explore_name} in {namespace}")

--- a/tests/test_funnel_analysis.py
+++ b/tests/test_funnel_analysis.py
@@ -31,6 +31,7 @@ def funnel_analysis_explore(tmp_path, funnel_analysis_view):
     )
     return FunnelAnalysisExplore(
         "funnel_analysis",
+        "glean_app",
         {"base_view": "funnel_analysis"},
         tmp_path,
     )
@@ -80,7 +81,7 @@ def test_view_from_dict(funnel_analysis_view):
 
 def test_explore_from_views(funnel_analysis_view):
     expected = FunnelAnalysisExplore(
-        "funnel_analysis", {"base_view": "funnel_analysis"}
+        "funnel_analysis", "glean_app", {"base_view": "funnel_analysis"}
     )
     views = [funnel_analysis_view]
     actual = next(FunnelAnalysisExplore.from_views(views))
@@ -277,5 +278,5 @@ def test_explore_lookml(funnel_analysis_explore):
         {"name": "event_names", "hidden": "yes"},
     ]
 
-    actual = funnel_analysis_explore.to_lookml()
+    actual = funnel_analysis_explore.to_lookml(None)
     print_and_test(expected=expected, actual=actual)

--- a/tests/test_funnel_analysis.py
+++ b/tests/test_funnel_analysis.py
@@ -31,7 +31,6 @@ def funnel_analysis_explore(tmp_path, funnel_analysis_view):
     )
     return FunnelAnalysisExplore(
         "funnel_analysis",
-        "glean_app",
         {"base_view": "funnel_analysis"},
         tmp_path,
     )
@@ -81,7 +80,7 @@ def test_view_from_dict(funnel_analysis_view):
 
 def test_explore_from_views(funnel_analysis_view):
     expected = FunnelAnalysisExplore(
-        "funnel_analysis", "glean_app", {"base_view": "funnel_analysis"}
+        "funnel_analysis", {"base_view": "funnel_analysis"}
     )
     views = [funnel_analysis_view]
     actual = next(FunnelAnalysisExplore.from_views(views))

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -590,7 +590,7 @@ def test_lookml_actual(
         glean_app = Mock()
         glean_app.get_probes.return_value = msg_glean_probes
         glean_app.get_ping_descriptions.return_value = {
-            "baseline": "The baseline ping is foo."
+            "baseline": "The baseline ping\n    is foo."
         }
         mock.return_value = glean_app
 


### PR DESCRIPTION
Format should be `Explore for <x> ping. <x ping description>`. For
example, for the metrics ping, you would see:

```
Explore for the metrics ping. The metrics ping is intended for all of
the metrics that are explicitly set by the application or are included
in the application's metrics.yaml file (except events). The reported
data is tied to the ping's measurement window, which is the time
between the collection of two metrics ping. Ideally, this window is
expected to be about 24 hours, given that the collection is scheduled
daily at 4AM. Data in the ping_info section of the ping can be used to
infer the length of this window.
```
