### PR TITLE
Pull in descriptions from BQ for dimensions (fixes #138)

### DIFF
--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -1,6 +1,6 @@
 """Utils for generating lookml."""
 import re
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import click
 from google.cloud import bigquery
@@ -33,7 +33,9 @@ MAP_LAYER_NAMES = {
 }
 
 
-def _get_dimension(path: Tuple[str, ...], field_type: str, mode: str) -> Dict[str, Any]:
+def _get_dimension(
+    path: Tuple[str, ...], field_type: str, mode: str, description: Optional[str]
+) -> Dict[str, Any]:
     result: Dict[str, Any] = {}
     result["sql"] = "${TABLE}." + ".".join(path)
     name = path
@@ -75,6 +77,10 @@ def _get_dimension(path: Tuple[str, ...], field_type: str, mode: str) -> Dict[st
         if path in MAP_LAYER_NAMES:
             result["map_layer_name"] = MAP_LAYER_NAMES[path]
     result["name"] = "__".join(name)
+
+    if description:
+        result["description"] = description
+
     return result
 
 
@@ -85,7 +91,9 @@ def _generate_dimensions_helper(
         if field.field_type == "RECORD" and not field.mode == "REPEATED":
             yield from _generate_dimensions_helper(field.fields, *prefix, field.name)
         else:
-            yield _get_dimension((*prefix, field.name), field.field_type, field.mode)
+            yield _get_dimension(
+                (*prefix, field.name), field.field_type, field.mode, field.description
+            )
 
 
 def _generate_dimensions(client: bigquery.Client, table: str) -> List[Dict[str, Any]]:

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -42,7 +42,11 @@ class MockClient:
                 schema=[
                     SchemaField("client_id", "STRING"),
                     SchemaField("country", "STRING"),
-                    SchemaField("document_id", "STRING"),
+                    SchemaField(
+                        "document_id",
+                        "STRING",
+                        description="The document ID specified in the URI when the client sent this message",
+                    ),
                 ],
             )
         if table_ref == "mozdata.glean_app.baseline_clients_daily":
@@ -658,6 +662,7 @@ def test_lookml_actual_baseline_view(
                             "hidden": "yes",
                             "sql": "${TABLE}.document_id",
                             "primary_key": "yes",
+                            "description": "The document ID specified in the URI when the client sent this message",
                         },
                     ],
                     "measures": [


### PR DESCRIPTION
Fixes https://github.com/mozilla/lookml-generator/issues/138

Adds descriptions to dimensions if they are available in BQ