### PR TITLE
Stop generate script if any command exits non-zero

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -262,6 +262,7 @@ function push_and_open_spoke_pull_request() {
 }
 
 function main() {
+  set -e  # stop if any statement returns a non-zero exit code
   pushd .
   cd /app
 


### PR DESCRIPTION
I believe `mozilla_vpn` is missing views because `lookml-generator` is throwing an error and this script isn't stopping.