### PR TITLE
Remove type from Glean Metric Dimensions (fixes #99)

### DIFF
--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -249,17 +249,18 @@ class GleanPingView(PingView):
         if not group_label:
             group_label = "Glean"
 
+        friendly_name = f"{group_label} {group_item_label}"
+
         lookml = {
             "name": looker_name,
+            "label": friendly_name,
             "sql": sql_map[looker_name]["sql"],
             "type": sql_map[looker_name]["type"],
             "group_label": group_label,
             "group_item_label": group_item_label,
             "links": [
                 {
-                    "label": (
-                        f"Glean Dictionary reference for {group_label} {group_item_label}"
-                    ),
+                    "label": (f"Glean Dictionary reference for {friendly_name}"),
                     "url": (
                         f"https://dictionary.telemetry.mozilla.org"
                         f"/apps/{self.namespace}/metrics/{category}{sep}{name}"

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -897,6 +897,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Boolean",
                             "group_label": "Test",
                             "name": "metrics__boolean__test_boolean",
+                            "label": "Test Boolean",
                             "sql": "${TABLE}.metrics.boolean.test_boolean",
                             "type": "yesno",
                             "links": [
@@ -911,6 +912,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Counter",
                             "group_label": "Test",
                             "name": "metrics__counter__test_counter",
+                            "label": "Test Counter",
                             "description": "test counter description",
                             "sql": "${TABLE}.metrics.counter.test_counter",
                             "type": "number",
@@ -935,6 +937,7 @@ def test_lookml_actual_metrics_view(
                                 }
                             ],
                             "name": "metrics__counter__no_category_counter",
+                            "label": "Glean No Category Counter",
                             "sql": "${TABLE}.metrics.counter.no_category_counter",
                             "type": "number",
                         },
@@ -942,6 +945,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Metrics Ping Count",
                             "group_label": "Glean Validation",
                             "name": "metrics__counter__glean_validation_metrics_ping_count",
+                            "label": "Glean Validation Metrics Ping Count",
                             "sql": "${TABLE}.metrics.counter.glean_validation_metrics_ping_count",  # noqa: E501
                             "type": "number",
                             "links": [
@@ -956,6 +960,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Custom Distribution Sum",
                             "group_label": "Test",
                             "name": "metrics__custom_distribution__test_custom_distribution__sum",
+                            "label": "Test Custom Distribution Sum",
                             "sql": "${TABLE}.metrics.custom_distribution.test_custom_distribution.sum",
                             "type": "number",
                             "links": [
@@ -970,6 +975,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Datetime",
                             "group_label": "Test",
                             "name": "metrics__datetime__test_datetime",
+                            "label": "Test Datetime",
                             "sql": "${TABLE}.metrics.datetime.test_datetime",
                             "type": "string",
                             "links": [
@@ -984,6 +990,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Jwe",
                             "group_label": "Test",
                             "name": "metrics__jwe__test_jwe",
+                            "label": "Test Jwe",
                             "sql": "${TABLE}.metrics.jwe.test_jwe",
                             "type": "string",
                             "links": [
@@ -998,6 +1005,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Memory Distribution Sum",
                             "group_label": "Test",
                             "name": "metrics__memory_distribution__test_memory_distribution__sum",
+                            "label": "Test Memory Distribution Sum",
                             "sql": "${TABLE}.metrics.memory_distribution.test_memory_distribution.sum",
                             "type": "number",
                             "links": [
@@ -1012,6 +1020,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Quantity",
                             "group_label": "Test",
                             "name": "metrics__quantity__test_quantity",
+                            "label": "Test Quantity",
                             "sql": "${TABLE}.metrics.quantity.test_quantity",
                             "type": "number",
                             "links": [
@@ -1026,6 +1035,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "String",
                             "group_label": "Test",
                             "name": "metrics__string__test_string",
+                            "label": "Test String",
                             "sql": "${TABLE}.metrics.string.test_string",
                             "type": "string",
                             "links": [
@@ -1040,6 +1050,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Timing Distribution Sum",
                             "group_label": "Test",
                             "name": "metrics__timing_distribution__test_timing_distribution__sum",
+                            "label": "Test Timing Distribution Sum",
                             "sql": "${TABLE}.metrics.timing_distribution.test_timing_distribution.sum",
                             "type": "number",
                             "links": [
@@ -1054,6 +1065,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Rate Numerator",
                             "group_label": "Test",
                             "name": "metrics__rate__test_rate__numerator",
+                            "label": "Test Rate Numerator",
                             "sql": "${TABLE}.metrics.rate.test_rate.numerator",
                             "type": "number",
                             "links": [
@@ -1068,6 +1080,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Rate Denominator",
                             "group_label": "Test",
                             "name": "metrics__rate__test_rate__denominator",
+                            "label": "Test Rate Denominator",
                             "sql": "${TABLE}.metrics.rate.test_rate.denominator",
                             "type": "number",
                             "links": [
@@ -1082,6 +1095,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Timespan Value",
                             "group_label": "Test",
                             "name": "metrics__timespan__test_timespan__value",
+                            "label": "Test Timespan Value",
                             "sql": "${TABLE}.metrics.timespan.test_timespan.value",
                             "type": "number",
                             "links": [
@@ -1096,6 +1110,7 @@ def test_lookml_actual_metrics_view(
                             "group_item_label": "Uuid",
                             "group_label": "Test",
                             "name": "metrics__uuid__test_uuid",
+                            "label": "Test Uuid",
                             "sql": "${TABLE}.metrics.uuid.test_uuid",
                             "type": "string",
                             "links": [


### PR DESCRIPTION
This additional information isn't necessary, and looks redundant. For example: 

![image](https://user-images.githubusercontent.com/20569/129760799-f5bc7cb8-309c-41d3-83b2-32fe5cc43fdf.png)
