### PR TITLE
Remove views referencing experiment project

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -250,26 +250,6 @@ experimentation:
     - ascholtz@mozilla.com
   pretty_name: Experimentation
   views:
-    logs:
-      type: table_view
-      tables:
-        - channel: release
-          table: moz-fx-data-experiments.monitoring.logs
-    query_cost:
-      type: table_view
-      tables:
-        - channel: release
-          table: moz-fx-data-experiments.monitoring.query_cost_v1
-    task_monitoring_logs:
-      type: table_view
-      tables:
-        - channel: release
-          table: moz-fx-data-experiments.monitoring.task_monitoring_logs
-    task_profiling_logs:
-      type: table_view
-      tables:
-        - channel: release
-          table: moz-fx-data-experiments.monitoring.task_profiling_logs
     experiment_enrollment_daily_active_population:
       type: table_view
       tables:


### PR DESCRIPTION
Removed due to Airflow not having permission to access them. Will just add them manually to spoke