### PR TITLE
Add aggregate tables to speed up operational monitoring dashboards.

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -4,6 +4,7 @@ operational_monitoring:
   owners:
     - msamuel@mozilla.com
   pretty_name: Operational Monitoring
+  data_functions: ["compute_opmon_dimensions"]
 duet:
   glean_app: false
   owners:

--- a/generator/constants.py
+++ b/generator/constants.py
@@ -1,5 +1,5 @@
 """Constants."""
-from typing import Set
+from typing import List, Set
 
 # These are fields we don't need for opmon views/explores/dashboards
 OPMON_EXCLUDED_FIELDS: Set[str] = {
@@ -14,3 +14,11 @@ OPMON_EXCLUDED_FIELDS: Set[str] = {
     "histogram__range",
     "histogram__sum",
 }
+
+# These are fields we don't need for opmon dashboards
+OPMON_DASH_EXCLUDED_FIELDS: List[str] = [
+    "branch",
+    "probe",
+    "histogram__VALUES__key",
+    "histogram__VALUES__value",
+]

--- a/generator/dashboards/operational_monitoring_dashboard.py
+++ b/generator/dashboards/operational_monitoring_dashboard.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-from ..constants import OPMON_EXCLUDED_FIELDS
 from ..views import lookml_utils
 from .dashboard import Dashboard
 
@@ -32,60 +31,14 @@ class OperationalMonitoringDashboard(Dashboard):
         super().__init__(title, name, layout, namespace, tables)
 
     @classmethod
-    def _slug_to_title(self, slug):
-        return slug.replace("_", " ").title()
-
-    def _compute_dimension_data(self, bq_client, table, kwargs):
-        all_dimensions = lookml_utils._generate_dimensions(bq_client, table)
-        copy_excluded = OPMON_EXCLUDED_FIELDS.copy()
-        copy_excluded.update(self.OPMON_DASH_EXCLUDED_FIELDS)
-
-        relevant_dimensions = [
-            dimension
-            for dimension in all_dimensions
-            if dimension["name"] not in copy_excluded
-        ]
-
-        for dimension in relevant_dimensions:
-            dimension_name = dimension["name"]
-            query_job = bq_client.query(
-                f"""
-                    SELECT DISTINCT {dimension_name}, COUNT(*)
-                    FROM {table}
-                    GROUP BY 1
-                    ORDER BY 2 DESC
-                """
-            )
-
-            title = self._slug_to_title(dimension_name)
-            dimension_options = (
-                query_job.result().to_dataframe()[dimension_name].tolist()
-            )
-
-            dimension_kwarg = {
-                "title": title,
-                "name": dimension_name,
-            }
-
-            if len(dimension_options) > 0:
-                dimension_kwarg.update(
-                    {
-                        "default": dimension_options[0],
-                        "options": dimension_options[:10],
-                    }
-                )
-
-            kwargs["dimensions"].append(dimension_kwarg)
-
-    @classmethod
     def from_dict(
         klass, namespace: str, name: str, defn: dict
     ) -> OperationalMonitoringDashboard:
         """Get a OperationalMonitoringDashboard from a dict representation."""
-        title = klass._slug_to_title(name)
+        title = lookml_utils.slug_to_title(name)
         return klass(title, name, "newspaper", namespace, defn["tables"])
 
-    def to_lookml(self, bq_client):
+    def to_lookml(self, bq_client, data):
         """Get this dashboard as LookML."""
         kwargs = {
             "name": self.name,
@@ -95,34 +48,36 @@ class OperationalMonitoringDashboard(Dashboard):
             "dimensions": [],
         }
 
+        table_data = {}
+        for view_data in data.get("compute_opmon_dimensions", {}).values():
+            table_data.update(view_data)
+
         includes = []
+        graph_index = 0
         for table_defn in self.tables:
             if len(kwargs["dimensions"]) == 0:
-                self._compute_dimension_data(bq_client, table_defn["table"], kwargs)
+                kwargs["dimensions"] = table_data[table_defn["table"]]
 
-            query_job = bq_client.query(
-                f"""
-                    SELECT DISTINCT probe
-                    FROM {table_defn["table"]}
-                """
+            metrics = lookml_utils.get_distinct_vals(
+                bq_client, table_defn["table"], "probe"
             )
-            metrics = query_job.result().to_dataframe()["probe"].tolist()
             explore = table_defn["explore"]
             includes.append(
                 f"/looker-hub/{self.namespace}/explores/{explore}.explore.lkml"
             )
 
-            for i, metric in enumerate(metrics):
-                title = self._slug_to_title(metric)
+            for metric in metrics:
+                title = lookml_utils.slug_to_title(metric)
                 kwargs["elements"].append(
                     {
                         "title": title,
                         "metric": metric,
                         "explore": explore,
-                        "row": int(i / 2),
-                        "col": 0 if i % 2 == 0 else 12,
+                        "row": int(graph_index / 2) * 10,
+                        "col": 0 if graph_index % 2 == 0 else 12,
                     }
                 )
+                graph_index += 1
 
         model_lookml = lookml_utils.render_template(
             "model.lkml", "dashboards", **{"includes": includes}

--- a/generator/explores/client_counts_explore.py
+++ b/generator/explores/client_counts_explore.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
+from google.cloud import bigquery
+
 from ..views import View
 from . import Explore
 
@@ -37,7 +39,9 @@ class ClientCountsExplore(Explore):
         },
     ]
 
-    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+    def _to_lookml(
+        self, client: bigquery.Client, v1_name: Optional[str], data: Dict = {}
+    ) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         return [
             {

--- a/generator/explores/events_explore.py
+++ b/generator/explores/events_explore.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
+from google.cloud import bigquery
+
 from ..views import EventsView, View
 from .explore import Explore
 
@@ -44,7 +46,9 @@ class EventsExplore(Explore):
         """Get an instance of this explore from a dictionary definition."""
         return EventsExplore(name, defn["views"], views_path)
 
-    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+    def _to_lookml(
+        self, client: bigquery.Client, v1_name: Optional[str], data: Dict = {}
+    ) -> List[Dict[str, Any]]:
         lookml = {
             "name": "event_counts",
             "view_name": self.views["base_view"],

--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import lkml
+from google.cloud import bigquery
 
 from ..views.lookml_utils import escape_filter_expr
 
@@ -24,7 +25,9 @@ class Explore:
         """Explore instance represented as a dict."""
         return {self.name: {"type": self.type, "views": self.views}}
 
-    def to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+    def to_lookml(
+        self, client: bigquery.Client, v1_name: Optional[str], data: Dict = {}
+    ) -> List[Dict[str, Any]]:
         """
         Generate LookML for this explore.
 
@@ -59,13 +62,18 @@ class Explore:
                 ] = f"${{{base_view_name}.submission_date}} >= '2010-01-01'"
 
         # We only update the first returned explore
-        new_lookml = self._to_lookml(v1_name)
+        new_lookml = self._to_lookml(client, v1_name, data)
         base_lookml.update(new_lookml[0])
         new_lookml[0] = base_lookml
 
         return new_lookml
 
-    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+    def _to_lookml(
+        self,
+        client: bigquery.Client,
+        v1_name: Optional[str],
+        data: Dict = {},
+    ) -> List[Dict[str, Any]]:
         raise NotImplementedError("Only implemented in subclasses")
 
     def get_dependent_views(self) -> List[str]:

--- a/generator/explores/funnel_analysis_explore.py
+++ b/generator/explores/funnel_analysis_explore.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
+from google.cloud import bigquery
+
 from ..views import View
 from . import Explore
 
@@ -33,7 +35,9 @@ class FunnelAnalysisExplore(Explore):
         """Get an instance of this explore from a dictionary definition."""
         return FunnelAnalysisExplore(name, defn["views"], views_path)
 
-    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+    def _to_lookml(
+        self, client: bigquery.Client, v1_name: Optional[str], data: Dict = {}
+    ) -> List[Dict[str, Any]]:
         view_lookml = self.get_view_lookml("funnel_analysis")
         views = view_lookml["views"]
         n_events = len([d for d in views if d["name"].startswith("step_")])

--- a/generator/explores/glean_ping_explore.py
+++ b/generator/explores/glean_ping_explore.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
+from google.cloud import bigquery
 from mozilla_schema_generator.glean_ping import GleanPing
 
 from ..views import GleanPingView, View
@@ -15,7 +16,9 @@ class GleanPingExplore(PingExplore):
 
     type: str = "glean_ping_explore"
 
-    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+    def _to_lookml(
+        self, client: bigquery.Client, v1_name: Optional[str], data: Dict = {}
+    ) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         repo = next((r for r in GleanPing.get_repos() if r["name"] == v1_name))
         glean_app = GleanPing(repo)

--- a/generator/explores/growth_accounting_explore.py
+++ b/generator/explores/growth_accounting_explore.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
+from google.cloud import bigquery
+
 from ..views import View
 from . import Explore
 
@@ -13,7 +15,9 @@ class GrowthAccountingExplore(Explore):
 
     type: str = "growth_accounting_explore"
 
-    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+    def _to_lookml(
+        self, client: bigquery.Client, v1_name: Optional[str], data: Dict = {}
+    ) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         return [
             {

--- a/generator/explores/operational_monitoring_explore.py
+++ b/generator/explores/operational_monitoring_explore.py
@@ -1,10 +1,13 @@
 """Operational Monitoring Explore type."""
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from ..views import View
+from google.cloud import bigquery
+
+from ..views import View, lookml_utils
 from . import Explore
 
 
@@ -45,16 +48,57 @@ class OperationalMonitoringExplore(Explore):
         """Get an instance of this explore from a dictionary definition."""
         return OperationalMonitoringExplore(name, defn["views"], views_path, defn)
 
-    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+    def _to_lookml(
+        self,
+        bq_client: bigquery.Client,
+        v1_name: Optional[str],
+        data: Dict = {},
+    ) -> List[Dict[str, Any]]:
+        base_view_name = self.views["base_view"]
+
+        namespace_data = data.get("compute_opmon_dimensions", {}).get(
+            base_view_name, {}
+        )
+        table_name = (
+            "" if len(namespace_data.keys()) == 0 else list(namespace_data.keys())[0]
+        )
+        dimension_data = namespace_data[table_name]
+
+        filters = [
+            {f"{base_view_name}.branch": self.branches},
+            {f"{base_view_name}.percentile_conf": "50"},
+        ]
+        for dimension in dimension_data:
+            filters.append(
+                {f"{base_view_name}.{dimension['name']}": dimension["default"]}
+            )
+
+        aggregate_tables = []
+        probes = lookml_utils.get_distinct_vals(bq_client, table_name, "probe")
+        for probe in probes:
+            filters_copy = deepcopy(filters)
+            filters_copy.append({f"{base_view_name}.probe": probe})
+            aggregate_tables.append(
+                {
+                    "name": f"rollup_{probe}",
+                    "query": {
+                        "dimensions": ["build_id", "branch"],
+                        "measures": ["low", "high", "percentile"],
+                        "filters": filters_copy,
+                    },
+                    "materialization": {"sql_trigger_value": "SELECT CURRENT_DATE()"},
+                }
+            )
+
         defn: List[Dict[str, Any]] = [
             {
                 "name": self.views["base_view"],
                 "always_filter": {
                     "filters": [
-                        {"os": "Windows"},
                         {"branch": self.branches},
                     ]
                 },
+                "aggregate_table": aggregate_tables,
             },
         ]
 

--- a/generator/explores/ping_explore.py
+++ b/generator/explores/ping_explore.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
+from google.cloud import bigquery
+
 from ..views import PingView, View
 from . import Explore
 
@@ -13,7 +15,9 @@ class PingExplore(Explore):
 
     type: str = "ping_explore"
 
-    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+    def _to_lookml(
+        self, client: bigquery.Client, v1_name: Optional[str], data: Dict = {}
+    ) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         views_lookml = self.get_view_lookml(self.views["base_view"])
         views: List[str] = [view["name"] for view in views_lookml["views"]]

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -8,6 +8,7 @@ import lkml
 import yaml
 from google.cloud import bigquery
 
+from . import operational_monitoring_utils
 from .dashboards import DASHBOARD_TYPES
 from .explores import EXPLORE_TYPES
 from .namespaces import _get_glean_apps
@@ -36,6 +37,7 @@ def _generate_explores(
     v1_name: Optional[
         str
     ],  # v1_name for Glean explores: see: https://mozilla.github.io/probe-scraper/#tag/library
+    namespace_data: dict,
 ) -> Iterable[Path]:
     for explore_name, defn in explores.items():
         logging.info(f"Generating lookml for explore {explore_name} in {namespace}")
@@ -48,7 +50,7 @@ def _generate_explores(
                 f"/looker-hub/{namespace}/views/{view}.view.lkml"
                 for view in explore.get_dependent_views()
             ],
-            "explores": explore.to_lookml(v1_name),
+            "explores": explore.to_lookml(client, v1_name, namespace_data),
         }
         path = out_dir / (explore_name + ".explore.lkml")
         path.write_text(lkml.dump(file_lookml))
@@ -56,7 +58,12 @@ def _generate_explores(
 
 
 def _generate_dashboards(
-    client, dash_dir: Path, model_dir: Path, namespace: str, dashboards: dict
+    client,
+    dash_dir: Path,
+    model_dir: Path,
+    namespace: str,
+    dashboards: dict,
+    namespace_data: dict,
 ):
     for dashboard_name, dashboard_info in dashboards.items():
         logging.info(f"Generating lookml for dashboard {dashboard_name} in {namespace}")
@@ -65,7 +72,7 @@ def _generate_dashboards(
         )
 
         # A dashboard needs an associated model to render
-        dashboard_lookml, model_lookml = dashboard.to_lookml(client)
+        dashboard_lookml, model_lookml = dashboard.to_lookml(client, namespace_data)
 
         dash_path = dash_dir / f"{dashboard_name}.dashboard.lookml"
         model_path = model_dir / f"{dashboard_name}_data.model.lkml"
@@ -84,6 +91,24 @@ def _get_views_from_dict(views: Dict[str, ViewDict], namespace: str) -> Iterable
 
 def _glean_apps_to_v1_map(glean_apps):
     return {d["name"]: d["v1_name"] for d in glean_apps}
+
+
+def _append_data(bq_client, data_functions, view, namespace_data):
+    # For now, assume that data functions are applied
+    # to each table. Later it could be a mapping so only
+    # certain functions are applied to certain tables.
+    for function_name in data_functions:
+        if function_name not in namespace_data:
+            namespace_data[function_name] = {}
+
+        namespace_data[function_name][view.name] = {}
+
+        for table in view.tables:
+            table_name = table["table"]
+            data_function = getattr(operational_monitoring_utils, function_name)
+            namespace_data[function_name][view.name][table_name] = data_function(
+                bq_client, table_name
+            )
 
 
 def _lookml(namespaces, glean_apps, target_dir):
@@ -105,7 +130,13 @@ def _lookml(namespaces, glean_apps, target_dir):
 
         view_dir = target / namespace / "views"
         view_dir.mkdir(parents=True, exist_ok=True)
-        views = _get_views_from_dict(lookml_objects.get("views", {}), namespace)
+        views = list(_get_views_from_dict(lookml_objects.get("views", {}), namespace))
+
+        namespace_data = {}
+        for view in views:
+            _append_data(
+                client, lookml_objects.get("data_functions", []), view, namespace_data
+            )
 
         logging.info("  Generating views")
         v1_name: Optional[str] = v1_mapping.get(namespace)
@@ -117,7 +148,7 @@ def _lookml(namespaces, glean_apps, target_dir):
         explores = lookml_objects.get("explores", {})
         logging.info("  Generating explores")
         for explore_path in _generate_explores(
-            client, explore_dir, namespace, explores, view_dir, v1_name
+            client, explore_dir, namespace, explores, view_dir, v1_name, namespace_data
         ):
             logging.info(f"    ...Generating {explore_path}")
 
@@ -127,7 +158,7 @@ def _lookml(namespaces, glean_apps, target_dir):
         dashboard_dir.mkdir(parents=True, exist_ok=True)
         dashboards = lookml_objects.get("dashboards", {})
         for dashboard_path in _generate_dashboards(
-            client, dashboard_dir, namespace_dir, namespace, dashboards
+            client, dashboard_dir, namespace_dir, namespace, dashboards, namespace_data
         ):
             logging.info(f"    ...Generating {dashboard_path}")
 

--- a/generator/operational_monitoring_utils.py
+++ b/generator/operational_monitoring_utils.py
@@ -1,0 +1,59 @@
+"""Utils for operational monitoring."""
+from typing import Any, Dict, List
+
+from google.cloud import bigquery
+
+from .constants import OPMON_DASH_EXCLUDED_FIELDS, OPMON_EXCLUDED_FIELDS
+from .views import lookml_utils
+
+
+def compute_opmon_dimensions(
+    bq_client: bigquery.Client, table: str
+) -> List[Dict[str, Any]]:
+    """
+    Compute dimensions for Operational Monitoring.
+
+    For a given Operational Monitoring dimension, find its default (most common)
+    value and its top 10 most common to be used as dropdown options.
+    """
+    all_dimensions = lookml_utils._generate_dimensions(bq_client, table)
+    copy_excluded = OPMON_EXCLUDED_FIELDS.copy()
+    copy_excluded.update(OPMON_DASH_EXCLUDED_FIELDS)
+    dimensions = []
+
+    relevant_dimensions = [
+        dimension
+        for dimension in all_dimensions
+        if dimension["name"] not in copy_excluded
+    ]
+
+    for dimension in relevant_dimensions:
+        dimension_name = dimension["name"]
+        query_job = bq_client.query(
+            f"""
+                    SELECT DISTINCT {dimension_name}, COUNT(*)
+                    FROM {table}
+                    GROUP BY 1
+                    ORDER BY 2 DESC
+                """
+        )
+
+        title = lookml_utils.slug_to_title(dimension_name)
+        dimension_options = query_job.result().to_dataframe()[dimension_name].tolist()
+
+        dimension_kwarg = {
+            "title": title,
+            "name": dimension_name,
+        }
+
+        if len(dimension_options) > 0:
+            dimension_kwarg.update(
+                {
+                    "default": dimension_options[0],
+                    "options": dimension_options[:10],
+                }
+            )
+
+        dimensions.append(dimension_kwarg)
+
+    return dimensions

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -185,3 +185,20 @@ def render_template(filename, template_folder, **kwargs) -> str:
     template = env.get_template(filename)
     rendered = template.render(**kwargs)
     return rendered
+
+
+def get_distinct_vals(bq_client: bigquery.Client, table: str, column: str):
+    """Given a table and column name, return all distinct values for that column."""
+    query_job = bq_client.query(
+        f"""
+            SELECT DISTINCT {column}
+            FROM {table}
+        """
+    )
+    distinct_values = query_job.result().to_dataframe()[column].tolist()
+    return distinct_values
+
+
+def slug_to_title(slug):
+    """Convert a slug to title case."""
+    return slug.replace("_", " ").title()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -182,5 +182,5 @@ def test_explore_lookml(events_explore):
         },
     ]
 
-    actual = events_explore.to_lookml(None)
+    actual = events_explore.to_lookml(None, None)
     print_and_test(expected=expected, actual=actual)

--- a/tests/test_funnel_analysis.py
+++ b/tests/test_funnel_analysis.py
@@ -296,5 +296,5 @@ def test_explore_lookml(funnel_analysis_explore):
         {"name": "event_names", "hidden": "yes"},
     ]
 
-    actual = funnel_analysis_explore.to_lookml(None)
+    actual = funnel_analysis_explore.to_lookml(None, None)
     print_and_test(expected=expected, actual=actual)


### PR DESCRIPTION
This PR adds aggregate tables to Operational Monitoring explores to speed up their loading. [This branch](https://github.com/mozilla/looker-hub/tree/emtwo/aggregate_tables) in looker-hub has the changes that can be tested.

In order to add an aggregate table for each metric, the set of metrics associated with an explore need to be available to it including that metric's default values so it can be placed in the aggregate table. This data was already being processed in the dashboard. 

In order to avoid doing the same processing twice - in explores and in dashboards, I factored out that processing in the dashboard and turned it into generic data functions that can be applied to any namespace, called only once to perform processing, and accessed in both explores and dashboards.