### PR TITLE
Sort opmon dimensions so files are not regenerated unecessarily.

### DIFF
--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -193,6 +193,7 @@ def get_distinct_vals(bq_client: bigquery.Client, table: str, column: str):
         f"""
             SELECT DISTINCT {column}
             FROM {table}
+            ORDER BY {column}
         """
     )
     distinct_values = query_job.result().to_dataframe()[column].tolist()


### PR DESCRIPTION
the opmon files depending on this were being regenerated every day unnecessarily because the ordering changed.