### PR TITLE
Support submission_date on x-axis in operational monitoring.

### DIFF
--- a/generator/dashboards/templates/dashboard.lkml
+++ b/generator/dashboards/templates/dashboard.lkml
@@ -10,7 +10,7 @@
     explore: {{element.explore}}
     type: "looker_line"
     fields: [
-      {{element.explore}}.build_id,
+      {{element.explore}}.{{element.xaxis}},
       {{element.explore}}.branch,
       {{element.explore}}.high,
       {{element.explore}}.low,

--- a/generator/dashboards/templates/model.lkml
+++ b/generator/dashboards/templates/model.lkml
@@ -1,7 +1,0 @@
-connection: "telemetry"
-
-include: "dashboards/*.dashboard"
-
-{% for include in includes %}
-include: "{{include}}"
-{% endfor %}

--- a/generator/explores/operational_monitoring_explore.py
+++ b/generator/explores/operational_monitoring_explore.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterator, List, Optional
 
 from google.cloud import bigquery
 
+from .. import operational_monitoring_utils
 from ..views import View, lookml_utils
 from . import Explore
 
@@ -64,6 +65,8 @@ class OperationalMonitoringExplore(Explore):
         )
         dimension_data = namespace_data[table_name]
 
+        xaxis = operational_monitoring_utils.get_xaxis_val(bq_client, table_name)
+
         filters = [
             {f"{base_view_name}.branch": self.branches},
             {f"{base_view_name}.percentile_conf": "50"},
@@ -82,7 +85,7 @@ class OperationalMonitoringExplore(Explore):
                 {
                     "name": f"rollup_{probe}",
                     "query": {
-                        "dimensions": ["build_id", "branch"],
+                        "dimensions": [xaxis, "branch"],
                         "measures": ["low", "high", "percentile"],
                         "filters": filters_copy,
                     },

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -60,7 +60,6 @@ def _generate_explores(
 def _generate_dashboards(
     client,
     dash_dir: Path,
-    model_dir: Path,
     namespace: str,
     dashboards: dict,
     namespace_data: dict,
@@ -71,14 +70,9 @@ def _generate_dashboards(
             namespace, dashboard_name, dashboard_info
         )
 
-        # A dashboard needs an associated model to render
-        dashboard_lookml, model_lookml = dashboard.to_lookml(client, namespace_data)
-
+        dashboard_lookml = dashboard.to_lookml(client, namespace_data)
         dash_path = dash_dir / f"{dashboard_name}.dashboard.lookml"
-        model_path = model_dir / f"{dashboard_name}_data.model.lkml"
-
         dash_path.write_text(dashboard_lookml)
-        model_path.write_text(model_lookml)
         yield dash_path
 
 
@@ -153,12 +147,11 @@ def _lookml(namespaces, glean_apps, target_dir):
             logging.info(f"    ...Generating {explore_path}")
 
         logging.info("  Generating dashboards")
-        namespace_dir = target / namespace
-        dashboard_dir = namespace_dir / "dashboards"
+        dashboard_dir = target / namespace / "dashboards"
         dashboard_dir.mkdir(parents=True, exist_ok=True)
         dashboards = lookml_objects.get("dashboards", {})
         for dashboard_path in _generate_dashboards(
-            client, dashboard_dir, namespace_dir, namespace, dashboards, namespace_data
+            client, dashboard_dir, namespace, dashboards, namespace_data
         ):
             logging.info(f"    ...Generating {dashboard_path}")
 

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -78,7 +78,7 @@ def _get_db_views(uri):
 
 
 def _append_view_and_explore_for_data_type(
-    om_content, project_name, table_prefix, data_type, branches
+    om_content, project_name, table_prefix, data_type, branches, xaxis
 ):
     project_data_type_id = f"{project_name}_{data_type}"
 
@@ -86,7 +86,8 @@ def _append_view_and_explore_for_data_type(
         "type": f"operational_monitoring_{data_type}_view",
         "tables": [
             {
-                "table": f"{PROD_PROJECT}.operational_monitoring.{table_prefix}_{data_type}"
+                "table": f"{PROD_PROJECT}.operational_monitoring.{table_prefix}_{data_type}",
+                "xaxis": xaxis,
             }
         ],
     }
@@ -112,12 +113,17 @@ def _get_opmon_views_explores_dashboards():
             PROD_PROJECT, bucket, blob.name
         )
         table_prefix = _normalize_slug(om_project["slug"])
-        project_name = om_project["name"].lower()
+        project_name = "_".join(om_project["name"].lower().split(" "))
         branches = om_project.get("branches", ["enabled", "disabled"])
 
         for data_type in DATA_TYPES:
             _append_view_and_explore_for_data_type(
-                om_content, project_name, table_prefix, data_type, branches
+                om_content,
+                project_name,
+                table_prefix,
+                data_type,
+                branches,
+                om_project["xaxis"],
             )
 
         om_content["dashboards"][project_name] = {
@@ -130,7 +136,7 @@ def _get_opmon_views_explores_dashboards():
                 for data_type in DATA_TYPES
             ],
         }
-        return om_content
+    return om_content
 
 
 def _get_glean_apps(

--- a/generator/operational_monitoring_utils.py
+++ b/generator/operational_monitoring_utils.py
@@ -26,7 +26,6 @@ def compute_opmon_dimensions(
         for dimension in all_dimensions
         if dimension["name"] not in copy_excluded
     ]
-
     for dimension in relevant_dimensions:
         dimension_name = dimension["name"]
         query_job = bq_client.query(
@@ -57,3 +56,17 @@ def compute_opmon_dimensions(
         dimensions.append(dimension_kwarg)
 
     return dimensions
+
+
+def get_xaxis_val(bq_client: bigquery.Client, table: str) -> str:
+    """
+    Return whether the x-axis should be build_id or submission_date.
+
+    This is based on which one is found in the table provided.
+    """
+    all_dimensions = lookml_utils._generate_dimensions(bq_client, table)
+    return (
+        "build_id"
+        if "build_id" in {dimension["name"] for dimension in all_dimensions}
+        else "submission_date"
+    )

--- a/generator/views/operational_monitoring_histogram_view.py
+++ b/generator/views/operational_monitoring_histogram_view.py
@@ -50,7 +50,7 @@ class OperationalMonitoringHistogramView(OperationalMonitoringView):
         return {
             "views": [
                 {
-                    "name": "fission_histogram",
+                    "name": self.name,
                     "sql_table_name": reference_table,
                     "dimensions": self.dimensions,
                     "parameters": self.parameters,

--- a/generator/views/operational_monitoring_scalar_view.py
+++ b/generator/views/operational_monitoring_scalar_view.py
@@ -50,7 +50,7 @@ class OperationalMonitoringScalarView(OperationalMonitoringView):
         return {
             "views": [
                 {
-                    "name": "fission_scalar",
+                    "name": self.name,
                     "derived_table": {
                         "sql": dedent(
                             f"""

--- a/generator/views/operational_monitoring_view.py
+++ b/generator/views/operational_monitoring_view.py
@@ -1,4 +1,5 @@
 """Class to describe an Operational Monitoring View."""
+from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
@@ -15,11 +16,17 @@ class OperationalMonitoringView(PingView):
     def __init__(self, namespace: str, name: str, tables: List[Dict[str, str]]):
         """Create instance of a OperationalMonitoringView."""
         super().__init__(namespace, name, tables)
+        xaxis = tables[0]["xaxis"] if len(tables) > 0 else "build_id"
+
+        xaxis_to_sql_mapping = {
+            "build_id": f"PARSE_DATE('%Y%m%d', CAST(${{TABLE}}.{xaxis} AS STRING))",
+            "submission_date": f"${{TABLE}}.{xaxis}",
+        }
         self.dimensions: List[Dict[str, str]] = [
             {
-                "name": "build_id",
+                "name": xaxis,
                 "type": "date",
-                "sql": "PARSE_DATE('%Y%m%d', CAST(${TABLE}.build_id AS STRING))",
+                "sql": xaxis_to_sql_mapping[xaxis],
             }
         ]
         self.parameters: List[Dict[str, str]] = [
@@ -32,7 +39,9 @@ class OperationalMonitoringView(PingView):
         ]
 
     @classmethod
-    def from_dict(klass, namespace: str, name: str, _dict: ViewDict) -> PingView:
+    def from_dict(
+        klass, namespace: str, name: str, _dict: ViewDict
+    ) -> OperationalMonitoringView:
         """Get a OperationalMonitoringView from a dict representation."""
         return klass(namespace, name, _dict["tables"])
 

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -107,7 +107,7 @@ class MockBlob:
         self.updated = "2021-05-01"
 
     def download_as_string(self):
-        return '{"slug": "test", "name": "op_mon"}'
+        return '{"slug": "test", "name": "op_mon", "xaxis": "build_id"}'
 
 
 class MockBucket:
@@ -419,7 +419,8 @@ def test_namespaces_full(
                         "op_mon_histogram": {
                             "tables": [
                                 {
-                                    "table": "moz-fx-data-shared-prod.operational_monitoring.test_histogram"
+                                    "table": "moz-fx-data-shared-prod.operational_monitoring.test_histogram",
+                                    "xaxis": "build_id",
                                 }
                             ],
                             "type": "operational_monitoring_histogram_view",
@@ -427,7 +428,8 @@ def test_namespaces_full(
                         "op_mon_scalar": {
                             "tables": [
                                 {
-                                    "table": "moz-fx-data-shared-prod.operational_monitoring.test_scalar"
+                                    "table": "moz-fx-data-shared-prod.operational_monitoring.test_scalar",
+                                    "xaxis": "build_id",
                                 }
                             ],
                             "type": "operational_monitoring_scalar_view",

--- a/tests/test_operational_monitoring.py
+++ b/tests/test_operational_monitoring.py
@@ -153,8 +153,8 @@ class MockClient:
 def operational_monitoring_histogram_view():
     return OperationalMonitoringHistogramView(
         "operational_monitoring",
-        "fission",
-        [{"table": TABLE_HISTOGRAM}],
+        "fission_histogram",
+        [{"table": TABLE_HISTOGRAM, "xaxis": "build_id"}],
     )
 
 
@@ -162,8 +162,8 @@ def operational_monitoring_histogram_view():
 def operational_monitoring_scalar_view():
     return OperationalMonitoringScalarView(
         "operational_monitoring",
-        "fission",
-        [{"table": TABLE_SCALAR}],
+        "fission_scalar",
+        [{"table": TABLE_SCALAR, "xaxis": "submission_date"}],
     )
 
 
@@ -194,10 +194,10 @@ def operational_monitoring_dashboard():
 def test_view_from_dict(operational_monitoring_histogram_view):
     actual = OperationalMonitoringHistogramView.from_dict(
         "operational_monitoring",
-        "fission",
+        "fission_histogram",
         {
             "type": "operational_monitoring_histogram_view",
-            "tables": [{"table": TABLE_HISTOGRAM}],
+            "tables": [{"table": TABLE_HISTOGRAM, "xaxis": "build_id"}],
         },
     )
 
@@ -279,9 +279,8 @@ def test_scalar_view_lookml(operational_monitoring_scalar_view):
                 ],
                 "dimensions": [
                     {
-                        "name": "build_id",
-                        "sql": "PARSE_DATE('%Y%m%d', "
-                        "CAST(${TABLE}.build_id AS STRING))",
+                        "name": "submission_date",
+                        "sql": "${TABLE}.submission_date",
                         "type": "date",
                     },
                     {"name": "branch", "sql": "${TABLE}.branch", "type": "string"},
@@ -462,6 +461,6 @@ def test_dashboard_lookml(operational_monitoring_dashboard):
 
     """
     )
-    actual, _ = operational_monitoring_dashboard.to_lookml(mock_bq_client, DATA)
+    actual = operational_monitoring_dashboard.to_lookml(mock_bq_client, DATA)
 
     print_and_test(expected=expected, actual=dedent(actual))


### PR DESCRIPTION
This is the follow-up for https://github.com/mozilla/bigquery-etl/pull/2513. It also removes the unnecessary generation of model files.

The `looker-hub` branch for testing is [here](https://github.com/mozilla/looker-hub/tree/emtwo/submission_date)