### PR TITLE
Repeated nested field support for all explores

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -414,6 +414,11 @@ firefox_desktop:
       type: growth_accounting_explore
       views:
         base_view: growth_accounting
+    events:
+      type: events_explore
+      views:
+        base_view: events
+        extended_view: desktop_events_table
 pocket:
   glean_app: false
   owners:

--- a/generator/explores/client_counts_explore.py
+++ b/generator/explores/client_counts_explore.py
@@ -52,6 +52,7 @@ class ClientCountsExplore(Explore):
                     "filters": self.get_required_filters("extended_view"),
                 },
                 "queries": deepcopy(ClientCountsExplore.queries),
+                "joins": self.get_unnested_fields_joins_lookml(),
             }
         ]
 

--- a/generator/explores/events_explore.py
+++ b/generator/explores/events_explore.py
@@ -54,6 +54,7 @@ class EventsExplore(Explore):
             "view_name": self.views["base_view"],
             "description": "Event counts over time.",
             "queries": deepcopy(EventsExplore.queries),
+            "joins": self.get_unnested_fields_joins_lookml(),
         }
         required_filters = self.get_required_filters("extended_view")
         if required_filters:

--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import lkml
 from google.cloud import bigquery
 
-from ..views.lookml_utils import escape_filter_expr
+from ..views.lookml_utils import escape_filter_expr, slug_to_title
 
 
 @dataclass
@@ -120,14 +120,12 @@ class Explore:
                 view_name=view_name, views=views
             )
             metric_name = view_name
-            metric_label = metric_name.replace("_", " ").title()
+            metric_label = slug_to_title(metric_name)
 
             if view_name in extended_views:
                 # names of extended views are overriden by the name of the view that is extending them
-                metric_label = (
+                metric_label = slug_to_title(
                     metric_name.replace(base_name, parent_base_name)
-                    .replace("_", " ")
-                    .title()
                 )
                 base_name = parent_base_name
 

--- a/generator/explores/growth_accounting_explore.py
+++ b/generator/explores/growth_accounting_explore.py
@@ -23,6 +23,7 @@ class GrowthAccountingExplore(Explore):
             {
                 "name": self.name,
                 "view_name": self.views["base_view"],
+                "joins": self.get_unnested_fields_joins_lookml(),
             }
         ]
 

--- a/generator/explores/ping_explore.py
+++ b/generator/explores/ping_explore.py
@@ -19,25 +19,6 @@ class PingExplore(Explore):
         self, client: bigquery.Client, v1_name: Optional[str], data: Dict = {}
     ) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
-        views_lookml = self.get_view_lookml(self.views["base_view"])
-        views: List[str] = [view["name"] for view in views_lookml["views"]]
-
-        joins = []
-        for view in views_lookml["views"][1:]:
-            view_name = view["name"]
-            base_name, metric = self._get_base_name_and_metric(
-                view_name=view_name, views=views
-            )
-            joins.append(
-                {
-                    "name": view_name,
-                    "relationship": "one_to_many",
-                    "sql": (
-                        f"LEFT JOIN UNNEST(${{{base_name}.{metric}}}) AS {view_name} "
-                    ),
-                }
-            )
-
         return [
             {
                 "name": self.name,
@@ -45,7 +26,7 @@ class PingExplore(Explore):
                 "always_filter": {
                     "filters": self.get_required_filters("base_view"),
                 },
-                "joins": joins,
+                "joins": self.get_unnested_fields_joins_lookml(),
             }
         ]
 

--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -8,6 +8,7 @@ import click
 from mozilla_schema_generator.glean_ping import GleanPing
 from mozilla_schema_generator.probes import GleanProbe
 
+from .lookml_utils import slug_to_title
 from .ping_view import PingView
 
 DISTRIBUTION_TYPES = {
@@ -77,8 +78,7 @@ class GleanPingView(PingView):
                 suggest_name = f"suggest__{view_name}"
 
                 category, name = [
-                    v.replace("_", " ").title()
-                    for v in self._get_category_and_name(metric)
+                    slug_to_title(v) for v in self._get_category_and_name(metric)
                 ]
                 view_label = f"{category} - {name}"
                 metric_hidden = "no" if metric.is_in_source() else "yes"
@@ -168,7 +168,7 @@ class GleanPingView(PingView):
     def _get_links(self, dimension: dict) -> List[Dict[str, str]]:
         """Get a link annotation given a metric name."""
         name = self._get_name(dimension)
-        title = name.replace("_", " ").title()
+        title = slug_to_title(name)
         return [
             {
                 "label": (f"Glean Dictionary reference for {title}"),
@@ -249,8 +249,8 @@ class GleanPingView(PingView):
         if looker_name not in sql_map:
             return None
 
-        group_label = category.replace("_", " ").title()
-        group_item_label = label.replace("_", " ").title()
+        group_label = slug_to_title(category)
+        group_item_label = slug_to_title(label)
 
         if not group_label:
             group_label = "Glean"

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -51,8 +51,8 @@ def _get_dimension(
 
         group_label, group_item_label = None, None
         if len(path) > 1:
-            group_label = " ".join(path[:-1]).replace("_", " ").title()
-            group_item_label = path[-1].replace("_", " ").title()
+            group_label = slug_to_title(" ".join(path[:-1]))
+            group_item_label = slug_to_title(path[-1])
         if result["type"] == "time":
             # Remove _{type} suffix from the last path element for dimension group
             # names For example submission_date and submission_timestamp become

--- a/generator/views/operational_monitoring_view.py
+++ b/generator/views/operational_monitoring_view.py
@@ -16,7 +16,9 @@ class OperationalMonitoringView(PingView):
     def __init__(self, namespace: str, name: str, tables: List[Dict[str, str]]):
         """Create instance of a OperationalMonitoringView."""
         super().__init__(namespace, name, tables)
-        xaxis = tables[0]["xaxis"] if len(tables) > 0 else "build_id"
+        xaxis = "build_id"
+        if "xaxis" in tables[0] and len(tables) > 0:
+            xaxis = tables[0]["xaxis"]
 
         xaxis_to_sql_mapping = {
             "build_id": f"PARSE_DATE('%Y%m%d', CAST(${{TABLE}}.{xaxis} AS STRING))",

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -179,6 +179,7 @@ def test_explore_lookml(events_explore):
             },
             "sql_always_where": "${events.submission_date} >= '2010-01-01'",
             "queries": deepcopy(EventsExplore.queries),
+            "joins": [],
         },
     ]
 

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -1832,29 +1832,34 @@ def test_context_id(runner, glean_apps, tmp_path):
         )
 
         expected_explore = {
-            "includes": ["/looker-hub/custom/views/context.view.lkml"],
             "explores": [
                 {
-                    "sql_always_where": "${context.submission_date} >= '2010-01-01'",
-                    "view_name": "context",
                     "always_filter": {
                         "filters__all": [[{"submission_date": "28 days"}]]
                     },
                     "joins": [
                         {
-                            "relationship": "one_to_many",
-                            "sql": "LEFT JOIN UNNEST(${context.contexts}) AS context__contexts",
                             "name": "context__contexts",
+                            "relationship": "one_to_many",
+                            "sql": "LEFT JOIN UNNEST(${context.contexts}) "
+                            "AS context__contexts",
+                            "view_label": "Context  Contexts",
                         },
                         {
-                            "relationship": "one_to_many",
-                            "sql": "LEFT JOIN UNNEST(${context__contexts.position}) AS context__contexts__position",
                             "name": "context__contexts__position",
+                            "relationship": "one_to_many",
+                            "sql": "LEFT JOIN "
+                            "UNNEST(${context__contexts.position}) "
+                            "AS context__contexts__position",
+                            "view_label": "Context  Contexts  Position",
                         },
                     ],
                     "name": "context",
+                    "sql_always_where": "${context.submission_date} >= " "'2010-01-01'",
+                    "view_name": "context",
                 }
             ],
+            "includes": ["/looker-hub/custom/views/context.view.lkml"],
         }
 
         print_and_test(

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -1841,21 +1841,18 @@ def test_context_id(runner, glean_apps, tmp_path):
                         {
                             "name": "context__contexts",
                             "relationship": "one_to_many",
-                            "sql": "LEFT JOIN UNNEST(${context.contexts}) "
-                            "AS context__contexts",
+                            "sql": "LEFT JOIN UNNEST(${context.contexts}) AS context__contexts",
                             "view_label": "Context  Contexts",
                         },
                         {
                             "name": "context__contexts__position",
                             "relationship": "one_to_many",
-                            "sql": "LEFT JOIN "
-                            "UNNEST(${context__contexts.position}) "
-                            "AS context__contexts__position",
+                            "sql": "LEFT JOIN UNNEST(${context__contexts.position}) AS context__contexts__position",
                             "view_label": "Context  Contexts  Position",
                         },
                     ],
                     "name": "context",
-                    "sql_always_where": "${context.submission_date} >= " "'2010-01-01'",
+                    "sql_always_where": "${context.submission_date} >= '2010-01-01'",
                     "view_name": "context",
                 }
             ],


### PR DESCRIPTION
Fixes https://github.com/mozilla/lookml-generator/issues/310

Currently, we only have support for exposing repeated, nested fields in ping explores. There have been some requests of making these nested fields also available in other explores (client counts, event counts) etc.

Generated content on https://github.com/mozilla/looker-hub/tree/ascholtz-expand-unnested-test
Tested in Looker