### PR TITLE
Check if default dimension exists when adding opmon filters

### DIFF
--- a/generator/explores/operational_monitoring_explore.py
+++ b/generator/explores/operational_monitoring_explore.py
@@ -72,9 +72,10 @@ class OperationalMonitoringExplore(Explore):
             {f"{base_view_name}.percentile_conf": "50"},
         ]
         for dimension in dimension_data:
-            filters.append(
-                {f"{base_view_name}.{dimension['name']}": dimension["default"]}
-            )
+            if "default" in dimension:
+                filters.append(
+                    {f"{base_view_name}.{dimension['name']}": dimension["default"]}
+                )
 
         aggregate_tables = []
         probes = lookml_utils.get_distinct_vals(bq_client, table_name, "probe")


### PR DESCRIPTION
Yesterdays run has been failing with:

```
[2021-12-07 16:39:50,967] {{pod_launcher.py:149}} INFO - Traceback (most recent call last):
[2021-12-07 16:39:50,968] {{pod_launcher.py:149}} INFO -   File "/usr/local/bin/lookml-generator", line 33, in <module>
[2021-12-07 16:39:50,968] {{pod_launcher.py:149}} INFO -     sys.exit(load_entry_point('lookml-generator', 'console_scripts', 'lookml-generator')())
[2021-12-07 16:39:50,968] {{pod_launcher.py:149}} INFO -   File "/app/lookml-generator/generator/__main__.py", line 9, in main
[2021-12-07 16:39:50,968] {{pod_launcher.py:149}} INFO -     cli("generator")
[2021-12-07 16:39:50,968] {{pod_launcher.py:149}} INFO -   File "/app/lookml-generator/generator/__init__.py", line 37, in cli
[2021-12-07 16:39:50,968] {{pod_launcher.py:149}} INFO -     group(prog_name=prog_name)
[2021-12-07 16:39:50,969] {{pod_launcher.py:149}} INFO -   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
[2021-12-07 16:39:50,969] {{pod_launcher.py:149}} INFO -     return self.main(*args, **kwargs)
[2021-12-07 16:39:50,969] {{pod_launcher.py:149}} INFO -   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1053, in main
[2021-12-07 16:39:50,969] {{pod_launcher.py:149}} INFO -     rv = self.invoke(ctx)
[2021-12-07 16:39:50,969] {{pod_launcher.py:149}} INFO -   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
[2021-12-07 16:39:50,969] {{pod_launcher.py:149}} INFO -     return _process_result(sub_ctx.command.invoke(sub_ctx))
[2021-12-07 16:39:50,969] {{pod_launcher.py:149}} INFO -   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
[2021-12-07 16:39:50,969] {{pod_launcher.py:149}} INFO -     return ctx.invoke(self.callback, **ctx.params)
[2021-12-07 16:39:50,969] {{pod_launcher.py:149}} INFO -   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 754, in invoke
[2021-12-07 16:39:50,970] {{pod_launcher.py:149}} INFO -     return __callback(*args, **kwargs)
[2021-12-07 16:39:50,970] {{pod_launcher.py:149}} INFO -   File "/app/lookml-generator/generator/lookml.py", line 188, in lookml
[2021-12-07 16:39:50,970] {{pod_launcher.py:149}} INFO -     return _lookml(namespaces, glean_apps, target_dir)
[2021-12-07 16:39:50,970] {{pod_launcher.py:149}} INFO -   File "/app/lookml-generator/generator/lookml.py", line 152, in _lookml
[2021-12-07 16:39:50,970] {{pod_launcher.py:149}} INFO -     for explore_path in _generate_explores(
[2021-12-07 16:39:50,970] {{pod_launcher.py:149}} INFO -   File "/app/lookml-generator/generator/lookml.py", line 61, in _generate_explores
[2021-12-07 16:39:50,970] {{pod_launcher.py:149}} INFO -     "explores": explore.to_lookml(client, v1_name, namespace_data),
[2021-12-07 16:39:50,970] {{pod_launcher.py:149}} INFO -   File "/app/lookml-generator/generator/explores/explore.py", line 65, in to_lookml
[2021-12-07 16:39:50,970] {{pod_launcher.py:149}} INFO -     new_lookml = self._to_lookml(client, v1_name, data)
[2021-12-07 16:39:50,971] {{pod_launcher.py:149}} INFO -   File "/app/lookml-generator/generator/explores/operational_monitoring_explore.py", line 76, in _to_lookml
[2021-12-07 16:39:50,971] {{pod_launcher.py:149}} INFO -     {f"{base_view_name}.{dimension['name']}": dimension["default"]}
[2021-12-07 16:39:50,971] {{pod_launcher.py:149}} INFO - KeyError: 'default'
```