### PR TITLE
Generate deletion_request explores

### DIFF
--- a/generator/views/view.py
+++ b/generator/views/view.py
@@ -1,11 +1,11 @@
 """Generic class to describe Looker views."""
 from __future__ import annotations
 
-from typing import Any, Dict, Iterator, List, Optional, TypedDict
+from typing import Any, Dict, Iterator, List, Optional, Set, TypedDict
 
 from click import ClickException
 
-OMIT_VIEWS = {"deletion_request"}
+OMIT_VIEWS: Set[str] = set()
 
 
 class ViewDict(TypedDict):


### PR DESCRIPTION
Depends on https://github.com/mozilla/looker-hub/pull/33

There was some interest in having deletion_request explores in Looker. Currently, generation fails since a deletion_request had been manually added to looker-hub.