### PR TITLE
Distinct client counts

### DIFF
--- a/generator/views/client_counts_view.py
+++ b/generator/views/client_counts_view.py
@@ -63,15 +63,7 @@ class ClientCountsView(View):
             "type": "number",
             "description": "The number of clients, "
             "determined by whether they sent a baseline ping on the day in question.",
-            "sql": """
-              {% if client_counts.submission_date._is_selected or client_counts.days_since_first_seen._is_selected %}
-                -- This query is grouping on a dimension known to have 1 row per-client
-                COUNT(*)
-              {% else %}
-                -- This query is not grouping on a dimension that is known to have 1 row per-client
-                COUNT(DISTINCT client_id)
-              {% endif %}
-            """,
+            "sql": "COUNT(DISTINCT client_id)",
         }
     ]
 


### PR DESCRIPTION
fixes https://github.com/mozilla/lookml-generator/issues/429

I believe the main reason for checking for these conditions in the first place was performance. count(*) is potentially faster than using distinct, however since correctness is more important we should just always do a distinct count.

After merging we should keep and eye on whether this might break some existing PDTs.