### PR TITLE
Add active_users_aggregates_attribution to Looker namespaces

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -27,6 +27,10 @@ combined_browser_metrics:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.telemetry.active_users_aggregates_device
+    active_users_aggregates_attribution:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.telemetry.active_users_aggregates_attribution
     cohort_daily_statistics:
       type: table_view
       tables:


### PR DESCRIPTION
Add active_users_aggregates_attribution  to looker namespaces to enable analysis by attribution campaign, content, experiment, medium, source and variation.