### PR TITLE
Move search_term_sanitization_job_metadata_daily to spoke-private

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -82,6 +82,22 @@ activity_stream:
       type: ping_explore
       views:
         base_view: impression_stats_flat
+search_private:
+  glean_app: false
+  connection: bigquery-oauth
+  pretty_name: Search
+  owners:
+    - mmccorquodale@mozilla.com
+    - xluo@mozilla.com
+    - skahmann@mozilla.com
+    - wbrahic@mozilla.com
+    - ctroy@mozilla.com
+  spoke: looker-spoke-private
+  views:
+    search_term_sanitization_job_metadata_daily:
+      type: table_view
+      tables:
+        - table: mozdata.search_terms_unsanitized_analysis.prototype_sanitation_job_metadata
 search:
   glean_app: false
   owners:
@@ -108,10 +124,6 @@ search:
       type: table_view
       tables:
         - table: mozdata.analysis.desktop_search_alert_latest_daily
-    search_term_sanitization_job_metadata_daily:
-      type: table_view
-      tables:
-        - table: mozdata.search_terms_unsanitized_analysis.prototype_sanitation_job_metadata
   explores:
     desktop_search_counts:
       type: ping_explore


### PR DESCRIPTION
The most recent lookml-generator Airflow task is failing with:

```
google.api_core.exceptions.Forbidden: 403 GET https://bigquery.googleapis.com/bigquery/v2/projects/mozdata/datasets/search_terms_unsanitized_analysis/tables/prototype_sanitation_job_metadata?prettyPrint=false: Access Denied: Table mozdata:search_terms_unsanitized_analysis.prototype_sanitation_job_metadata: Permission bigquery.tables.get denied on table mozdata:search_terms_unsanitized_analysis.prototype_sanitation_job_metadata (or it may not exist).
```

Since the table contains cat3 data, we'll need to use the `bigquery-oauth` connection (this will enforce that Looker will ask users to authenticate when querying this table and only if they have access permissions they'll be able to do so. Otherwise by default the Looker service account does not have access permissions to this table).

cc @chelseatroy 