### PR TITLE
Remove opmon aggregate tables

### DIFF
--- a/tests/test_operational_monitoring.py
+++ b/tests/test_operational_monitoring.py
@@ -325,42 +325,6 @@ def test_explore_lookml(operational_monitoring_explore):
     mock_bq_client = MockClient()
     expected = [
         {
-            "aggregate_table": [
-                {
-                    "name": "rollup_GC_MS",
-                    "query": {
-                        "dimensions": ["build_id", "branch"],
-                        "filters": [
-                            {"fission_histogram.branch": "enabled, " "disabled"},
-                            {"fission_histogram.percentile_conf": "50"},
-                            {"fission_histogram.cores_count": "4"},
-                            {"fission_histogram.os": "Windows"},
-                            {"fission_histogram.probe": "GC_MS"},
-                        ],
-                        "measures": ["low", "high", "percentile"],
-                    },
-                    "materialization": {
-                        "sql_trigger_value": "SELECT CAST(TIMESTAMP_SUB(CURRENT_TIMESTAMP, INTERVAL 9 HOUR) AS DATE)"
-                    },
-                },
-                {
-                    "name": "rollup_GC_MS_CONTENT",
-                    "query": {
-                        "dimensions": ["build_id", "branch"],
-                        "filters": [
-                            {"fission_histogram.branch": "enabled, " "disabled"},
-                            {"fission_histogram.percentile_conf": "50"},
-                            {"fission_histogram.cores_count": "4"},
-                            {"fission_histogram.os": "Windows"},
-                            {"fission_histogram.probe": "GC_MS_CONTENT"},
-                        ],
-                        "measures": ["low", "high", "percentile"],
-                    },
-                    "materialization": {
-                        "sql_trigger_value": "SELECT CAST(TIMESTAMP_SUB(CURRENT_TIMESTAMP, INTERVAL 9 HOUR) AS DATE)"
-                    },
-                },
-            ],
             "always_filter": {"filters": [{"branch": "enabled, disabled"}]},
             "name": "fission_histogram",
         }


### PR DESCRIPTION
Removing automatic aggregate table generation for OpMon tiles. 
The main reason is that aggregate tables will cache outdated information when setting x-axis to buildID. Each point of time refers to a specific build ID which gets updated during nightly ETL runs, so cached data points won't get updated in Looker.
Additionally, creating the aggregate tables is more costly than running queries for the dashboards users are actually interested in.