### PR TITLE
Get the metadata from the most up-to-date production table

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -97,7 +97,7 @@ search_private:
     search_term_sanitization_job_metadata_daily:
       type: table_view
       tables:
-        - table: mozdata.search_terms_unsanitized_analysis.prototype_sanitation_job_metadata
+        - table: moz-fx-data-shared-prod.search_terms_derived.sanitization_job_metadata_v2
     sanitization_job_languages:
       type: table_view
       tables:


### PR DESCRIPTION
Ultimately, we need to get this data from the production table rather than the prototype table we used for testing. This PR makes that change.