### PR TITLE
Add automated KPI forecasting tables

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -752,11 +752,27 @@ kpi:
       type: ping_view
       tables:
         - table: mozdata.telemetry.unified_metrics
+    automated_kpi_forecasts:
+      type: ping_view
+      tables:
+        - table: moz-fx-data-shared-prod.telemetry_derived.kpi_automated_forecast_v1
+    automated_kpi_confidence_intervals:
+      type: ping_view
+      tables:
+        - table: moz-fx-data-shared-prod.telemetry_derived.kpi_automated_forecast_confidences_v1
   explores:
     unified_metrics:
       type: ping_explore
       views:
         base_view: unified_metrics
+    automated_kpi_forecasts:
+      type: ping_explore
+      views:
+        base_view: automated_kpi_forecasts
+    automated_kpi_confidence_intervals:
+      type: ping_explore
+      views:
+        base_view: automated_kpi_confidence_intervals
 fpa:
   glean_app: false
   connection: bigquery-oauth


### PR DESCRIPTION
Relates to recent ticket updating the forecasting job: https://mozilla-hub.atlassian.net/browse/DS-2075

Required for revenue forecasting work (https://mozilla-hub.atlassian.net/browse/RS-324, https://mozilla-hub.atlassian.net/browse/RS-405)