### PR TITLE
modify the namespace for stable and dervied table size

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -619,6 +619,10 @@ monitoring:
       type: ping_view
       tables:
         - table: mozdata.monitoring.stable_table_sizes
+    stable_and_derived_table_sizes:
+      type: ping_view
+      tables:
+        - table: mozdata.monitoring.stable_and_derived_table_sizes
     stable_table_column_counts:
       type: ping_view
       tables:
@@ -680,6 +684,10 @@ monitoring:
       type: ping_explore
       views:
         base_view: stable_table_sizes
+    stable_and_dervied_table_sizes:
+      type: ping_explore
+      views:
+        base_view: stable_and_derived_table_sizes
     stable_table_column_counts:
       type: ping_explore
       views:


### PR DESCRIPTION
The PR https://github.com/mozilla/bigquery-etl/pull/3141  now enables to track partition sizes of the derived tables. More details are available here: https://bugzilla.mozilla.org/show_bug.cgi?id=1779053

This is a subsequent PR is to fix the looker dashboard to point to the new view i.e. `monitoring_derived.stable_and_derived_table_sizes_v1`
