### PR TITLE
Generate views & explores for Glean ping union views (DENG-210)

### DIFF
--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -43,8 +43,8 @@ class PingView(View):
                 if channel.get("channel") is not None:
                     table["channel"] = channel["channel"]
                 if (
-                    len(references) != 1
-                    or references[0][-2] != channel["source_dataset"]
+                    len(set(r[-1] for r in references)) != 1
+                    or channel["source_dataset"] not in [r[-2] for r in references]
                 ):
                     continue  # This view is only for ping tables
 

--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -42,11 +42,16 @@ class PingView(View):
 
                 if channel.get("channel") is not None:
                     table["channel"] = channel["channel"]
+
+                # Only include those that select from a single ping source table
+                # or union together multiple ping source tables of the same name.
+                reference_table_names = set(r[-1] for r in references)
+                reference_dataset_names = set(r[-2] for r in references)
                 if (
-                    len(set(r[-1] for r in references)) != 1
-                    or channel["source_dataset"] not in [r[-2] for r in references]
+                    len(reference_table_names) != 1
+                    or channel["source_dataset"] not in reference_dataset_names
                 ):
-                    continue  # This view is only for ping tables
+                    continue
 
                 views[view_id].append(table)
 


### PR DESCRIPTION
Glean ping views that union multiple sources are currently excluded from having views & explores generated.  This PR will generate views & explores for Glean ping views that union multiple sources as long as the table/view names are all the same (e.g. the VPN Glean ping union views added in mozilla/bigquery-etl#3140 for [DENG-210](https://mozilla-hub.atlassian.net/browse/DENG-210)).

[Test run results](https://github.com/mozilla/looker-hub/compare/DENG-210-glean-unioned-pings):
- `main` and `deletion_request` views & explores (re)generated for `mozilla_vpn`.
  - This is the main aim of this PR, since [those got unintentionally deleted](https://github.com/mozilla/looker-hub/commit/6ff45902a248d0151dd259c49771bf27beaa19e4#diff-9a13687d374409d7375c5752b9bf34e57673d21eebe6cd43e09dec724778e730) after mozilla/bigquery-etl#3140 & mozilla/bigquery-etl#3149).
- `baseline_clients_daily`, `baseline_clients_first_seen`, and `baseline_clients_last_seen` views & explores generated for `fenix`, `firefox_ios`, and `focus_android`.
  - `baseline_clients_daily` and `baseline_clients_last_seen` views already existed for `firefox_ios`, so those are [being](https://github.com/mozilla/looker-hub/compare/DENG-210-glean-unioned-pings#diff-a17a7efa5b82b698055e4a1beb8ddec283231051359087884655eac5b1d8dda8) [updated](https://github.com/mozilla/looker-hub/compare/DENG-210-glean-unioned-pings#diff-b6cd03c34e4a3c0f1b9b70f5b6fd542a83f649dab69b4ec04d15cad49d9cd498) and could use some extra scrutiny.
- `events_unnested` views & explores generated for `fenix`, `firefox_ios`, `focus_android`, and `mozilla_vpn`.