### PR TITLE
add search monthly view for desktop and mobile

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -120,10 +120,10 @@ search:
       type: ping_view
       tables:
         - table: mozdata.search.mobile_search_clients_engines_sources_daily
-    firefox_products_search_clients_engines_sources_daily:
+    desktop_mobile_search_clients_monthly:
       type: table_view
       tables:
-        - table: mozdata.search.firefox_products_search_clients_engines_sources_daily
+        - table: mozdata.search.desktop_mobile_search_clients_monthly
     desktop_search_alert_records:
       type: ping_view
       tables:


### PR DESCRIPTION
Add search monthly view to looker hub. 
Also, removes the previously added `firefox_products_search_clients_engines_sources_daily`