### PR TITLE
Set document_id as primary_key in event views when available

### DIFF
--- a/generator/views/events_view.py
+++ b/generator/views/events_view.py
@@ -73,6 +73,14 @@ class EventsView(View):
         )
         view_defn["measures"] = self.get_measures(dimensions)
 
+        # set document_id as primary key if it exists in the underlying table
+        # this will allow one_to_many joins
+        document_id_field = self.get_document_id(dimensions, "events")
+        if document_id_field is not None:
+            view_defn["dimensions"] = [
+                {"name": document_id_field, "primary_key": "yes"}
+            ]
+
         return {
             "includes": [f"{self.tables[0]['events_table_view']}.view.lkml"],
             "views": [view_defn],

--- a/generator/views/view.py
+++ b/generator/views/view.py
@@ -112,3 +112,15 @@ class View(object):
         if len(client_id_fields) > 1:
             raise ClickException(f"Duplicate client_id dimension in {table!r}")
         return client_id_fields[0]
+
+    def get_document_id(self, dimensions: List[dict], table: str) -> Optional[str]:
+        """Return the first field that looks like a document_id."""
+        document_id_fields = [
+            d["name"] for d in dimensions if d["name"] in {"document_id"}
+        ]
+        if not document_id_fields:
+            # Some pings purposely disinclude client_ids, e.g. firefox installer
+            return None
+        if len(document_id_fields) > 1:
+            raise ClickException(f"Duplicate document_id dimension in {table!r}")
+        return document_id_fields[0]


### PR DESCRIPTION
This PR fixes the `cannot be calculated because of a one_to_many or many_to_many join` errors in the event explores.

These docs were helpful in figuring out the problem: https://cloud.google.com/looker/docs/best-practices/how-to-troubleshoot-when-measures-dont-come-through-a-join

To enable measures to carry through joins (such as client count and event count), we need to define a primary key in the involved views. `document_id` is the natural choice here as primary key for the event views.

I pushed the changes to a branch in looker-hub to test them and the join worked just as expected: https://github.com/mozilla/looker-hub/tree/ascholtz-events-join-test-1

cc @skahmann3 