### PR TITLE
Add data validation metrics table

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -102,6 +102,10 @@ search_private:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.search_terms.sanitization_job_languages
+    search_term_data_validation_reports:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.search_terms_derived.search_term_data_validation_reports_v1
 search:
   glean_app: false
   owners:


### PR DESCRIPTION
This table contains info that we use to determine whether to alert data scientists to sea changes in our aggregate search data metrics. Our plan is to use Looker alarms for the alerting, so I'll be making views with this table and attaching alarms to them. 