### PR TITLE
Fix location for crashes_daily looker view

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -140,10 +140,6 @@ search:
       type: table_view
       tables:
         - table: mozdata.analysis.desktop_search_alert_latest_daily
-    desktop_crashes_daily:
-      type: table_view
-      tables:
-        - table: mozdata.telemetry.crashes_daily
   explores:
     desktop_search_counts:
       type: ping_explore
@@ -554,6 +550,10 @@ firefox_desktop:
       type: table_view
       tables:
         - table: mozdata.telemetry.newtab_interactions
+    crashes_daily:
+      type: table_view
+      tables:
+        - table: mozdata.telemetry.crashes_daily
   explores:
     client_counts:
       type: client_counts_explore


### PR DESCRIPTION
Also, remove `desktop` from the name. It's now in the desktop namespace.