### PR TITLE
Bug(DS-2132): FxA accounts dashboard is broken client id not found

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -334,6 +334,7 @@ firefox_accounts:
           table: mozdata.firefox_accounts.events_daily
     growth_accounting:
       type: growth_accounting_view
+      primary_key_field: user_id
       tables:
         - table: mozdata.firefox_accounts.fxa_users_last_seen
     fxa_first_seen_table:

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -334,7 +334,7 @@ firefox_accounts:
           table: mozdata.firefox_accounts.events_daily
     growth_accounting:
       type: growth_accounting_view
-      primary_key_field: user_id
+      identifier_field: user_id
       tables:
         - table: mozdata.firefox_accounts.fxa_users_last_seen
     fxa_first_seen_table:

--- a/generator/views/growth_accounting_view.py
+++ b/generator/views/growth_accounting_view.py
@@ -13,7 +13,7 @@ class GrowthAccountingView(View):
     """A view for growth accounting measures."""
 
     type: str = "growth_accounting_view"
-    DEFAULT_PRIMARY_FIELD: str = "client_id"
+    DEFAULT_IDENTIFIER_FIELD: str = "client_id"
 
     other_dimensions: List[Dict[str, str]] = [
         {
@@ -184,10 +184,10 @@ class GrowthAccountingView(View):
         self,
         namespace: str,
         tables: List[Dict[str, str]],
-        primary_key_field: str = DEFAULT_PRIMARY_FIELD,
+        identifier_field: str = DEFAULT_IDENTIFIER_FIELD,
     ):
         """Get an instance of a GrowthAccountingView."""
-        self.primary_key_field = primary_key_field
+        self.identifier_field = identifier_field
 
         super().__init__(
             namespace, "growth_accounting", GrowthAccountingView.type, tables
@@ -195,7 +195,7 @@ class GrowthAccountingView(View):
 
     @classmethod
     def get_default_dimensions(
-        klass, primary_key_field: str = DEFAULT_PRIMARY_FIELD
+        klass, identifier_field: str = DEFAULT_IDENTIFIER_FIELD
     ) -> List[Dict[str, str]]:
         """Get dimensions to be added to GrowthAccountingView by default."""
         return [
@@ -224,8 +224,8 @@ class GrowthAccountingView(View):
                 "hidden": "yes",
             },
             {
-                "name": f"{primary_key_field}_day",
-                "sql": f"CONCAT(CAST(${{TABLE}}.submission_date AS STRING), ${{{primary_key_field}}})",
+                "name": f"{identifier_field}_day",
+                "sql": f"CONCAT(CAST(${{TABLE}}.submission_date AS STRING), ${{{identifier_field}}})",
                 "type": "string",
                 "hidden": "yes",
                 "primary_key": "yes",
@@ -239,7 +239,7 @@ class GrowthAccountingView(View):
         is_glean: bool,
         channels: List[Dict[str, str]],
         db_views: dict,
-        primary_key_field: str = DEFAULT_PRIMARY_FIELD,
+        identifier_field: str = DEFAULT_IDENTIFIER_FIELD,
     ) -> Iterator[GrowthAccountingView]:
         """Get Growth Accounting Views from db views and app variants."""
         dataset = next(
@@ -252,7 +252,7 @@ class GrowthAccountingView(View):
                 yield GrowthAccountingView(
                     namespace,
                     [{"table": f"mozdata.{dataset}.{view_id}"}],
-                    primary_key_field=primary_key_field,
+                    identifier_field=identifier_field,
                 )
 
     @classmethod
@@ -263,9 +263,9 @@ class GrowthAccountingView(View):
         return GrowthAccountingView(
             namespace,
             _dict["tables"],
-            primary_key_field=str(
+            identifier_field=str(
                 _dict.get(
-                    "primary_key_field", GrowthAccountingView.DEFAULT_PRIMARY_FIELD
+                    "identifier_field", GrowthAccountingView.DEFAULT_IDENTIFIER_FIELD
                 )
             ),
         )
@@ -278,7 +278,7 @@ class GrowthAccountingView(View):
         # add dimensions and dimension groups
         dimensions = lookml_utils._generate_dimensions(bq_client, table) + deepcopy(
             GrowthAccountingView.get_default_dimensions(
-                primary_key_field=self.primary_key_field
+                identifier_field=self.identifier_field
             )
         )
 

--- a/generator/views/growth_accounting_view.py
+++ b/generator/views/growth_accounting_view.py
@@ -13,6 +13,7 @@ class GrowthAccountingView(View):
     """A view for growth accounting measures."""
 
     type: str = "growth_accounting_view"
+    DEFAULT_PRIMARY_FIELD: str = "client_id"
 
     other_dimensions: List[Dict[str, str]] = [
         {
@@ -183,7 +184,7 @@ class GrowthAccountingView(View):
         self,
         namespace: str,
         tables: List[Dict[str, str]],
-        primary_key_field: str = "client_id",
+        primary_key_field: str = DEFAULT_PRIMARY_FIELD,
     ):
         """Get an instance of a GrowthAccountingView."""
         self.primary_key_field = primary_key_field
@@ -193,7 +194,10 @@ class GrowthAccountingView(View):
         )
 
     @classmethod
-    def _get_default_dimensions(klass, primary_key_field: str) -> List[Dict[str, str]]:
+    def get_default_dimensions(
+        klass, primary_key_field: str = DEFAULT_PRIMARY_FIELD
+    ) -> List[Dict[str, str]]:
+        """Get dimensions to be added to GrowthAccountingView by default."""
         return [
             {
                 "name": "active_this_week",
@@ -235,7 +239,7 @@ class GrowthAccountingView(View):
         is_glean: bool,
         channels: List[Dict[str, str]],
         db_views: dict,
-        primary_key_field: str = "client_id",
+        primary_key_field: str = DEFAULT_PRIMARY_FIELD,
     ) -> Iterator[GrowthAccountingView]:
         """Get Growth Accounting Views from db views and app variants."""
         dataset = next(
@@ -259,7 +263,11 @@ class GrowthAccountingView(View):
         return GrowthAccountingView(
             namespace,
             _dict["tables"],
-            primary_key_field=str(_dict.get("primary_key_field", "client_id")),
+            primary_key_field=str(
+                _dict.get(
+                    "primary_key_field", GrowthAccountingView.DEFAULT_PRIMARY_FIELD
+                )
+            ),
         )
 
     def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
@@ -269,7 +277,7 @@ class GrowthAccountingView(View):
 
         # add dimensions and dimension groups
         dimensions = lookml_utils._generate_dimensions(bq_client, table) + deepcopy(
-            GrowthAccountingView._get_default_dimensions(
+            GrowthAccountingView.get_default_dimensions(
                 primary_key_field=self.primary_key_field
             )
         )

--- a/generator/views/growth_accounting_view.py
+++ b/generator/views/growth_accounting_view.py
@@ -179,7 +179,12 @@ class GrowthAccountingView(View):
         },
     ]
 
-    def __init__(self, namespace: str, tables: List[Dict[str, str]], primary_key_field: str = "client_id"):
+    def __init__(
+        self,
+        namespace: str,
+        tables: List[Dict[str, str]],
+        primary_key_field: str = "client_id",
+    ):
         """Get an instance of a GrowthAccountingView."""
         self.primary_key_field = primary_key_field
 
@@ -241,7 +246,9 @@ class GrowthAccountingView(View):
         for view_id, references in db_views[dataset].items():
             if view_id == "baseline_clients_last_seen":
                 yield GrowthAccountingView(
-                    namespace, [{"table": f"mozdata.{dataset}.{view_id}"}], primary_key_field=primary_key_field
+                    namespace,
+                    [{"table": f"mozdata.{dataset}.{view_id}"}],
+                    primary_key_field=primary_key_field,
                 )
 
     @classmethod
@@ -249,7 +256,11 @@ class GrowthAccountingView(View):
         klass, namespace: str, name: str, _dict: ViewDict
     ) -> GrowthAccountingView:
         """Get a view from a name and dict definition."""
-        return GrowthAccountingView(namespace, _dict["tables"], primary_key_field=_dict.get("primary_key_field", "client_id"))
+        return GrowthAccountingView(
+            namespace,
+            _dict["tables"],
+            primary_key_field=str(_dict.get("primary_key_field", "client_id")),
+        )
 
     def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
         """Generate LookML for this view."""
@@ -258,7 +269,9 @@ class GrowthAccountingView(View):
 
         # add dimensions and dimension groups
         dimensions = lookml_utils._generate_dimensions(bq_client, table) + deepcopy(
-            GrowthAccountingView._get_default_dimensions(primary_key_field=self.primary_key_field)
+            GrowthAccountingView._get_default_dimensions(
+                primary_key_field=self.primary_key_field
+            )
         )
 
         view_defn["dimensions"] = list(

--- a/generator/views/growth_accounting_view.py
+++ b/generator/views/growth_accounting_view.py
@@ -13,6 +13,8 @@ class GrowthAccountingView(View):
     """A view for growth accounting measures."""
 
     type: str = "growth_accounting_view"
+    primary_key_field: Optional[str] = "client_id"
+
     other_dimensions: List[Dict[str, str]] = [
         {
             "name": "first",
@@ -48,8 +50,8 @@ class GrowthAccountingView(View):
             "hidden": "yes",
         },
         {
-            "name": "client_id_day",
-            "sql": "CONCAT(CAST(${TABLE}.submission_date AS STRING), client_id)",
+            "name": f"{primary_key_field}_day",
+            "sql": f"CONCAT(CAST(${{submission_date}} AS STRING), ${{{primary_key_field}}})",
             "type": "string",
             "hidden": "yes",
             "primary_key": "yes",
@@ -212,8 +214,10 @@ class GrowthAccountingView(View):
         },
     ]
 
-    def __init__(self, namespace: str, tables: List[Dict[str, str]]):
+    def __init__(self, namespace: str, tables: List[Dict[str, str]], primary_key_field: str = "client_id"):
         """Get an instance of a GrowthAccountingView."""
+        self.primary_key_field = primary_key_field
+
         super().__init__(
             namespace, "growth_accounting", GrowthAccountingView.type, tables
         )

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -1564,7 +1564,7 @@ def test_lookml_actual_growth_accounting_view(
                             "sql": "${TABLE}.document_id",
                         },
                     ]
-                    + GrowthAccountingView.default_dimensions,
+                    + GrowthAccountingView.get_default_dimensions(),
                     "measures": GrowthAccountingView.default_measures,
                 }
             ]

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -55,7 +55,7 @@ def custom_namespaces(tmp_path):
               views:
                 growth_accounting:
                   type: growth_accounting_view
-                  primary_key_field: user_id
+                  identifier_field: user_id
                   tables:
                   - table: mozdata.firefox_accounts.fxa_users_last_seen
             custom:
@@ -304,7 +304,7 @@ def test_namespaces_full(
                     "views": {
                         "growth_accounting": {
                             "type": "growth_accounting_view",
-                            "primary_key_field": "user_id",
+                            "identifier_field": "user_id",
                             "tables": [
                                 {
                                     "table": "mozdata.firefox_accounts.fxa_users_last_seen",

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -47,6 +47,17 @@ def custom_namespaces(tmp_path):
                   projects:
                     tables:
                     - table: mozdata.operational_monitoring.projects
+            firefox_accounts:
+              pretty_name: Firefox Accounts
+              glean_app: false
+              owners:
+              - custom-owner@allizom.com
+              views:
+                growth_accounting:
+                  type: growth_accounting_view
+                  primary_key_field: user_id
+                  tables:
+                  - table: mozdata.firefox_accounts.fxa_users_last_seen
             custom:
               connection: bigquery-oauth
               glean_app: false
@@ -281,6 +292,25 @@ def test_namespaces_full(
                             ],
                             "type": "table_view",
                         },
+                    },
+                },
+                "firefox_accounts": {
+                    "glean_app": False,
+                    "owners": [
+                        "custom-owner@allizom.com",
+                    ],
+                    "pretty_name": "Firefox Accounts",
+                    "spoke": "looker-spoke-default",
+                    "views": {
+                        "growth_accounting": {
+                            "type": "growth_accounting_view",
+                            "primary_key_field": "user_id",
+                            "tables": [
+                                {
+                                    "table": "mozdata.firefox_accounts.fxa_users_last_seen",
+                                }
+                            ],
+                        }
                     },
                 },
                 "glean-app": {


### PR DESCRIPTION
# bug(DS-2132): FxA accounts dashboard is broken client id not found

Seems the change resulted in expected changes:
https://github.com/mozilla/looker-hub/blob/kik-generation-test-1/firefox_accounts/views/growth_accounting.view.lkml#L103-L108