### PR TITLE
default source branch set to main in generate script

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -13,7 +13,7 @@
 #   HUB_REPO_URL:             The URL to the looker-hub repository.
 #                             Requires the SSH format, e.g. git@github.com:user/repo.git.
 #   HUB_BRANCH_SOURCE:        The source branch for generating LookML.
-#                             Defaults to 'base'. Files present the source
+#                             Defaults to 'main'. Files present the source
 #                             branch will remain unchanged by generation.
 #   HUB_BRANCH_PUBLISH:       The destination branch for publishing LookML.
 #                             Defaults to 'test-lookml-generation'. If the
@@ -49,7 +49,7 @@
 #   make build && make run
 
 HUB_REPO_URL=${HUB_REPO_URL:-"git@github.com:mozilla/looker-hub.git"}
-HUB_BRANCH_SOURCE=${HUB_BRANCH_SOURCE:-"base"}
+HUB_BRANCH_SOURCE=${HUB_BRANCH_SOURCE:-"main"}
 HUB_BRANCH_PUBLISH=${HUB_BRANCH_PUBLISH:-"main-nonprod"}
 
 SPOKE_REPO_URL=${SPOKE_REPO_URL:-"git@github.com:mozilla/looker-spoke-default.git"}


### PR DESCRIPTION
I'm not sure if this is a mistake or intended. I suspect this is why my generated branch results with 400 commits behind main in looker-hub repo.


However, now trying to run make run command seems to result in the following kinds of errors:
```
Error: lookml-generator modified <view_path>.view.lkml
```

So perhaps the use of `base` branch here is correct?