### PR TITLE
Create new looker-hub publish branches from `main` branch

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -107,8 +107,8 @@ function setup_hub() {
     git clone "$HUB_REPO_URL"
     cd looker-hub
     git fetch --all
-    # If publish branch doesn't exist, create it from source
-    git checkout "$HUB_BRANCH_PUBLISH" || (git checkout "$HUB_BRANCH_SOURCE" && git checkout -b "$HUB_BRANCH_PUBLISH")
+    # If publish branch doesn't exist, create it from main
+    git checkout "$HUB_BRANCH_PUBLISH" || (git checkout main && git checkout -b "$HUB_BRANCH_PUBLISH")
     git checkout "$HUB_BRANCH_SOURCE"
 
     popd


### PR DESCRIPTION
New [looker-hub](https://github.com/mozilla/looker-hub) publish branches (e.g. for testing [lookml-generator](https://github.com/mozilla/lookml-generator) code changes) were being created from the [`base` branch](https://github.com/mozilla/looker-hub/tree/base), which resulted in essentially every file showing up as changed on such branches after lookml-generator runs.

This will now work the same as new [looker-spoke-default](https://github.com/mozilla/looker-spoke-default) publish branches, which are [also being created from its `main` branch](https://github.com/mozilla/lookml-generator/blob/83048aa9cdefcf6c66bc82ecce64b67606c049d4/bin/generate#L129).
