### PR TITLE
Reference url metrics under their other name (`url2`) in generated views

### DIFF
--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -29,6 +29,15 @@ ALLOWED_TYPES = DISTRIBUTION_TYPES | {
     "rate",
     "timespan",
     "uuid",
+    "url",
+}
+
+# Bug 1737656 - some metric types are exposed under different names
+# We need to map to the new name when building dimensions.
+RENAMED_METRIC_TYPES = {
+    "jwe": "jwe2",
+    "text": "text2",
+    "url": "url2",
 }
 
 
@@ -241,7 +250,8 @@ class GleanPingView(PingView):
 
         sep = "" if not category else "_"
         label = name
-        looker_name = f"metrics__{metric.type}__{category}{sep}{name}"
+        type = RENAMED_METRIC_TYPES.get(metric.type, metric.type)
+        looker_name = f"metrics__{type}__{category}{sep}{name}"
         if suffix:
             label = f"{name}_{suffix}"
             looker_name = f"{looker_name}__{suffix}"

--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -20,16 +20,19 @@ DISTRIBUTION_TYPES = {
 
 ALLOWED_TYPES = DISTRIBUTION_TYPES | {
     "boolean",
+    "labeled_boolean",
     "counter",
     "labeled_counter",
     "datetime",
     "jwe",
     "quantity",
     "string",
+    "labeled_string",
     "rate",
     "timespan",
     "uuid",
     "url",
+    "text",
 }
 
 # Bug 1737656 - some metric types are exposed under different names

--- a/requirements.txt
+++ b/requirements.txt
@@ -762,7 +762,7 @@ wheel==0.36.2 \
     --hash=sha256:e11eefd162658ea59a60a0f6c7d493a7190ea4b9a85e335b33489d9f17e0245e
     # via pip-tools
 yamllint==1.28.0 \
-    --hash=sha256:9e3d8ddd16d0583214c5fdffe806c9344086721f107435f68bad990e5a88826b
+    --hash=sha256:89bb5b5ac33b1ade059743cf227de73daa34d5e5a474b06a5e17fc16583b0cf2
     # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -239,7 +239,7 @@ class MockClient:
                                 fields=[SchemaField("test_datetime", "STRING")],
                             ),
                             SchemaField(
-                                "jwe",
+                                "jwe2",
                                 "RECORD",
                                 fields=[SchemaField("test_jwe", "STRING")],
                             ),
@@ -398,6 +398,11 @@ class MockClient:
                                 "uuid",
                                 "RECORD",
                                 fields=[SchemaField("test_uuid", "STRING")],
+                            ),
+                            SchemaField(
+                                "url2",
+                                "RECORD",
+                                fields=[SchemaField("test_url", "STRING")],
                             ),
                         ],
                     ),
@@ -641,6 +646,15 @@ def msg_glean_probes():
                 "type": "uuid",
                 "history": history,
                 "name": "test.uuid",
+                "in-source": True,
+            },
+        ),
+        GleanProbe(
+            "test.url",
+            {
+                "type": "url",
+                "history": history,
+                "name": "test.url",
                 "in-source": True,
             },
         ),
@@ -1133,9 +1147,9 @@ def test_lookml_actual_metrics_view(
                         {
                             "group_item_label": "Jwe",
                             "group_label": "Test",
-                            "name": "metrics__jwe__test_jwe",
+                            "name": "metrics__jwe2__test_jwe",
                             "label": "Test Jwe",
-                            "sql": "${TABLE}.metrics.jwe.test_jwe",
+                            "sql": "${TABLE}.metrics.jwe2.test_jwe",
                             "type": "string",
                             "hidden": "no",
                             "links": [
@@ -1271,6 +1285,22 @@ def test_lookml_actual_metrics_view(
                                     "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
                                     "label": "Glean Dictionary reference for Test Uuid",
                                     "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/test_uuid",  # noqa: E501
+                                }
+                            ],
+                        },
+                        {
+                            "group_item_label": "Url",
+                            "group_label": "Test",
+                            "name": "metrics__url2__test_url",
+                            "label": "Test Url",
+                            "sql": "${TABLE}.metrics.url2.test_url",
+                            "type": "string",
+                            "hidden": "no",
+                            "links": [
+                                {
+                                    "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
+                                    "label": "Glean Dictionary reference for Test Url",
+                                    "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/test_url",  # noqa: E501
                                 }
                             ],
                         },


### PR DESCRIPTION
Fixes #539