### PR TITLE
Fix deprecation warning for relocated import

### DIFF
--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -5,7 +5,8 @@ import re
 import tarfile
 import urllib.request
 import warnings
-from collections import Mapping, defaultdict
+from collections import defaultdict
+from collections.abc import Mapping
 from datetime import datetime
 from io import BytesIO
 from itertools import groupby


### PR DESCRIPTION
current import path will be removed in python 3.10 