### PR TITLE
Support multiple client count views in a single namespace

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -569,10 +569,18 @@ firefox_desktop:
       type: client_counts_view
       tables:
         - table: mozdata.telemetry.clients_daily
+    sponsored_tiles_clients_daily_table:
+      type: table_view
+      tables:
+        - table: mozdata.telemetry.sponsored_tiles_clients_daily
     sponsored_tiles_clients_daily:
       type: client_counts_view
       tables:
         - table: mozdata.telemetry.sponsored_tiles_clients_daily
+    suggest_clients_daily_table:
+      type: table_view
+      tables:
+        - table: mozdata.telemetry.suggest_clients_daily
     suggest_clients_daily:
       type: client_counts_view
       tables:
@@ -623,10 +631,12 @@ firefox_desktop:
       type: client_counts_explore
       views:
         base_view: sponsored_tiles_clients_daily
+        extended_view: sponsored_tiles_clients_daily_table
     suggest_clients_daily:
       type: client_counts_explore
       views:
         base_view: suggest_clients_daily
+        extended_view: suggest_clients_daily_table
     funnel_analysis:
       type: funnel_analysis_explore
       views:

--- a/generator/views/client_counts_view.py
+++ b/generator/views/client_counts_view.py
@@ -67,9 +67,14 @@ class ClientCountsView(View):
         }
     ]
 
-    def __init__(self, namespace: str, tables: List[Dict[str, str]]):
+    def __init__(
+        self,
+        namespace: str,
+        tables: List[Dict[str, str]],
+        name: str = "client_counts",
+    ):
         """Get an instance of a ClientCountsView."""
-        super().__init__(namespace, "client_counts", ClientCountsView.type, tables)
+        super().__init__(namespace, name, ClientCountsView.type, tables)
 
     @classmethod
     def from_db_views(
@@ -99,7 +104,7 @@ class ClientCountsView(View):
         klass, namespace: str, name: str, _dict: ViewDict
     ) -> ClientCountsView:
         """Get a view from a name and dict definition."""
-        return ClientCountsView(namespace, _dict["tables"])
+        return ClientCountsView(namespace, _dict["tables"], name)
 
     def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
         """Generate LookML for this view."""


### PR DESCRIPTION
The `firefox_desktop` namespace now has multiple client count explores. However, when generating the views they are currently always named `client_counts`. So the same view gets overridden. Instead we want to be able to generate multiple client count views and use their configured names.

cc @rebecca-burwei 