### PR TITLE
Changed (glean) event counts name in namespaces.yaml to fit explore naming convention

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -662,7 +662,7 @@ firefox_desktop:
       views:
         base_view: events
         extended_view: desktop_events_table
-    glean_events:
+    glean_event_counts:
       type: events_explore
       views:
         base_view: events


### PR DESCRIPTION
https://github.com/mozilla/looker-hub/commit/731b68ab81df20c6294b4f5bd95013919c8e0185 contained invalid lookml due to having the same explore name defined twice in the `firefox_desktop` model, once in `firefox_desktop/explores/glean_events.explore.lkml` after https://github.com/mozilla/lookml-generator/pull/579 and the existing `firefox_desktop/explores/events.explore.lkml`

```
"error": "Model Error : Could not load model 'firefox_desktop'. : [\"An explore named \\\"event_counts\\\" has been defined multiple times. Each explore in a model must have a unique name.\", \"An explore named \\\"event_counts\\\" has been defined multiple times. Each explore in a model must have a unique name.\"]"
```

Custom names for an `events_explore` must end in `_counts`: https://github.com/mozilla/lookml-generator/blob/f24ff3041f1c708710b2102821d4490c7bf7a4a9/generator/explores/events_explore.py#L40-L41