### PR TITLE
[DS-2284]Adding Relay tables to custom-namespace.yaml for Relay SaaSboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ namespaces.yaml
 looker-hub/
 .env
 .vscode
+.python-version

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1022,3 +1022,26 @@ data_integrity_monitoring:
       tables:
         - table: data-monitoring-dev.dim.dim_muted_alerts
       type: table_view
+relay:
+  glean_app: false
+  owners:
+    - srose@mozilla.com
+    - ysmith@mozilla.com
+  pretty_name: Firefox Relay
+  views:
+    subscriptions:
+      type: table_view
+      subscriptions:
+        - table: mozdata.relay.subscriptions
+    subscription_events:
+      type: table_view
+      tables:
+        - table: mozdata.relay.subscription_events
+    active_subscriptions:
+      type: table_view
+      tables:
+        - table: mozdata.relay.active_subscriptions
+    active_subscription_ids:
+      type: table_view
+      tables:
+        - table: mozdata.relay.active_subscription_ids


### PR DESCRIPTION
In order to monitor Relay metrics in real time, the derived tables were created in [this PR](https://github.com/mozilla/bigquery-etl/pull/3482). They need to be added to Looker for the Relay SaaSboard. 