### PR TITLE
bug(1809409): fixing custom-namespace configuration for relay

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1031,7 +1031,7 @@ relay:
   views:
     subscriptions:
       type: table_view
-      subscriptions:
+      tables:
         - table: mozdata.relay.subscriptions
     subscription_events:
       type: table_view


### PR DESCRIPTION
# bug(1809409): fixing custom-namespace configuration for relay