### PR TITLE
Generate datagroups

### DIFF
--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -12,6 +12,7 @@ from .dashboards import DASHBOARD_TYPES
 from .explores import EXPLORE_TYPES
 from .namespaces import _get_glean_apps
 from .views import VIEW_TYPES, View, ViewDict
+from .views.datagroups import generate_datagroups
 
 FILE_HEADER = """
 # *Do not manually modify this file*
@@ -119,6 +120,9 @@ def _lookml(namespaces, glean_apps, target_dir):
         v1_name: Optional[str] = v1_mapping.get(namespace)
         for view_path in _generate_views(client, view_dir, views, v1_name):
             logging.info(f"    ...Generating {view_path}")
+
+        logging.info("  Generating datagroups")
+        generate_datagroups(views, target, namespace, client)
 
         explore_dir = target / namespace / "explores"
         explore_dir.mkdir(parents=True, exist_ok=True)

--- a/generator/views/datagroups.py
+++ b/generator/views/datagroups.py
@@ -1,0 +1,162 @@
+"""Generate datagroup lkml files for each namespace."""
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import lkml
+from google.api_core.exceptions import NotFound
+from google.cloud import bigquery
+
+from generator.namespaces import DEFAULT_GENERATED_SQL_URI
+from generator.views import TableView, View, lookml_utils
+from generator.views.lookml_utils import BQViewReferenceMap
+
+DEFAULT_MAX_CACHE_AGE = "24 hours"
+DEFAULT_INTERVAL_TRIGGER = "6 hours"
+
+# Note: INFORMATION_SCHEMA.PARTITIONS has a row with a `last_modified_time` value even for non-partitioned tables.
+SQL_TRIGGER_TEMPLATE = """
+    SELECT MAX(last_modified_time)
+    FROM `{project_id}`.{dataset_id}.INFORMATION_SCHEMA.PARTITIONS
+    WHERE table_name = '{table_id}'
+"""
+
+FILE_HEADER = """# *Do not manually modify this file*
+
+# This file has been generated via https://github.com/mozilla/lookml-generator
+
+# Using a datagroup in an Explore: https://cloud.google.com/looker/docs/reference/param-explore-persist-with
+# Using a datagroup in a derived table: https://cloud.google.com/looker/docs/reference/param-view-datagroup-trigger
+
+"""
+
+
+@dataclass
+class Datagroup:
+    """Represents a Datagroup."""
+
+    name: str
+    label: str
+    sql_trigger: str
+    description: str
+    max_cache_age: str = DEFAULT_MAX_CACHE_AGE
+    interval_trigger: str = DEFAULT_INTERVAL_TRIGGER
+
+    def __str__(self) -> str:
+        """Return the LookML string representation of a Datagroup."""
+        return lkml.dump({"datagroups": [self.__dict__]})  # type: ignore
+
+
+def _get_datagroup_from_bigquery_table(table: bigquery.Table) -> Datagroup:
+    """Use template and default values to create a Datagroup from a BQ Table."""
+    return Datagroup(
+        name=f"{table.table_id}_last_updated",
+        label=f"{table.friendly_name or table.table_id} Last Updated",
+        description=f"Updates when {table.full_table_id} is modified.",
+        sql_trigger=SQL_TRIGGER_TEMPLATE.format(
+            project_id=table.project,
+            dataset_id=table.dataset_id,
+            table_id=table.table_id,
+        ),
+        # Note: Ideally we'd use the table's ETL schedule as the `maximum_cache_age` but we don't have schedule
+        # metadata here.
+    )
+
+
+def _get_datagroup_from_bigquery_view(
+    view: bigquery.Table,
+    client: bigquery.Client,
+    dataset_view_map: Dict[str, BQViewReferenceMap],
+) -> Optional[Datagroup]:
+    # Dataset view map only contains references for shared-prod views.
+    if view.project not in ("moz-fx-data-shared-prod", "mozdata"):
+        logging.debug(
+            f"Unable to get sources for non shared-prod/mozdata view: {view.full_table_id} in generated-sql."
+        )
+        return None
+
+    dataset_view_references = dataset_view_map.get(view.dataset_id)
+    if dataset_view_references is None:
+        logging.debug(f"Unable to find dataset {view.dataset_id} in generated-sql.")
+        return None
+
+    view_references = dataset_view_references.get(view.table_id)
+    if not view_references or len(view_references) > 1:
+        # For views with multiple sources it's unclear which table to check for updates.
+        logging.debug(
+            f"Unable to find a single source for {view.full_table_id} in generated-sql."
+        )
+        return None
+
+    source_table_id = ".".join(view_references[0])
+    try:
+        table = client.get_table(source_table_id)
+        if "TABLE" == table.table_type:
+            return _get_datagroup_from_bigquery_table(table)
+        elif "VIEW" == table.table_type:
+            return _get_datagroup_from_bigquery_view(table, client, dataset_view_map)
+    except NotFound as e:
+        raise ValueError(
+            f"Unable to find {source_table_id} referenced in {view.full_table_id}"
+        ) from e
+
+    return None
+
+
+def _generate_view_datagroup_lkml(
+    view: View,
+    client: bigquery.Client,
+    dataset_view_map: Dict[str, BQViewReferenceMap],
+) -> str:
+    """Generate the Datagroup LookML for a Looker View."""
+    # Only generate datagroup for views that can be linked to a BigQuery table:
+    if view.view_type != TableView.type:
+        return ""
+
+    # Use the release channel table or the first available table (usually the only one):
+    view_table = next(
+        (table for table in view.tables if table.get("channel") == "release"),
+        view.tables[0],
+    )["table"]
+
+    try:
+        bq_table = client.get_table(view_table)
+    except NotFound as e:
+        raise ValueError(
+            f"{view_table} not found when generating datagroup but in namespaces yaml."
+        ) from e
+
+    if "TABLE" == bq_table.table_type:
+        datagroup: Optional[Datagroup] = _get_datagroup_from_bigquery_table(bq_table)
+        return str(datagroup)
+    elif "VIEW" == bq_table.table_type:
+        datagroup = _get_datagroup_from_bigquery_view(
+            bq_table, client, dataset_view_map
+        )
+        if datagroup is not None:
+            return str(datagroup)
+
+    return ""
+
+
+def generate_datagroups(
+    views: List[View], target_dir: Path, namespace: str, client: bigquery.Client
+) -> None:
+    """Generate and write a datagroups.lkml file to the namespace folder."""
+    datagroups_lkml_path = target_dir / namespace / "datagroups.lkml"
+
+    # To map views to their underlying tables:
+    dataset_view_map = lookml_utils.get_bigquery_view_reference_map(
+        DEFAULT_GENERATED_SQL_URI
+    )
+
+    datagroup_content = [
+        lookml
+        for view in views
+        if (lookml := _generate_view_datagroup_lkml(view, client, dataset_view_map))
+    ]
+
+    if datagroup_content:
+        datagroups_lkml_path.write_text(FILE_HEADER + "\n\n".join(datagroup_content))

--- a/generator/views/datagroups.py
+++ b/generator/views/datagroups.py
@@ -3,7 +3,7 @@
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import lkml
 from google.api_core.exceptions import NotFound
@@ -68,7 +68,7 @@ def _get_datagroup_from_bigquery_table(table: bigquery.Table) -> Datagroup:
 def _get_datagroup_from_bigquery_view(
     view: bigquery.Table,
     client: bigquery.Client,
-    dataset_view_map: Dict[str, BQViewReferenceMap],
+    dataset_view_map: BQViewReferenceMap,
 ) -> Optional[Datagroup]:
     # Dataset view map only contains references for shared-prod views.
     if view.project not in ("moz-fx-data-shared-prod", "mozdata"):
@@ -108,7 +108,7 @@ def _get_datagroup_from_bigquery_view(
 def _generate_view_datagroup_lkml(
     view: View,
     client: bigquery.Client,
-    dataset_view_map: Dict[str, BQViewReferenceMap],
+    dataset_view_map: BQViewReferenceMap,
 ) -> str:
     """Generate the Datagroup LookML for a Looker View."""
     # Only generate datagroup for views that can be linked to a BigQuery table:

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -216,17 +216,17 @@ def slug_to_title(slug):
     return slug.replace("_", " ").title()
 
 
-# Map from view to qualified references {view: [[project, dataset, table],]}
-BQViewReferenceMap = Dict[str, List[List[str]]]
+# Map from view to qualified references {dataset: {view: [[project, dataset, table],]}}
+BQViewReferenceMap = Dict[str, Dict[str, List[List[str]]]]
 
 
 def get_bigquery_view_reference_map(
     generated_sql_uri: str,
-) -> Dict[str, BQViewReferenceMap]:
+) -> BQViewReferenceMap:
     """Get a mapping from BigQuery datasets to views with references."""
     with urllib.request.urlopen(generated_sql_uri) as f:
         tarbytes = BytesIO(f.read())
-    views: Dict[str, BQViewReferenceMap] = defaultdict(dict)
+    views: BQViewReferenceMap = defaultdict(dict)
     with tarfile.open(fileobj=tarbytes, mode="r:gz") as tar:
         for tarinfo in tar:
             if tarinfo.name.endswith("/metadata.yaml"):

--- a/tests/test_datagroups.py
+++ b/tests/test_datagroups.py
@@ -1,0 +1,235 @@
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from google.cloud import bigquery
+
+from generator.views import EventsView, TableView
+from generator.views.datagroups import generate_datagroups
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@dataclass
+class MockTable(bigquery.Table):
+    full_table_id: str
+    table_id: str
+    friendly_name: str
+    table_type: str
+
+
+@patch("google.cloud.bigquery.Table")
+@patch("google.cloud.bigquery.Table")
+@patch("google.cloud.bigquery.Client")
+@patch("generator.views.lookml_utils.get_bigquery_view_reference_map")
+def test_generates_datagroups(reference_map_mock, client, table_1, table_2, runner):
+    expected = """# *Do not manually modify this file*
+
+# This file has been generated via https://github.com/mozilla/lookml-generator
+
+# Using a datagroup in an Explore: https://cloud.google.com/looker/docs/reference/param-explore-persist-with
+# Using a datagroup in a derived table: https://cloud.google.com/looker/docs/reference/param-view-datagroup-trigger
+
+datagroup: test_table_last_updated {
+  label: "Test Table Last Updated"
+  sql_trigger: SELECT MAX(last_modified_time)
+    FROM `mozdata`.analysis.INFORMATION_SCHEMA.PARTITIONS
+    WHERE table_name = 'test_table' ;;
+  description: "Updates when mozdata:analysis.test_table is modified."
+  max_cache_age: "24 hours"
+  interval_trigger: 6 hours
+}
+
+datagroup: test_table_2_last_updated {
+  label: "Test Table 2 Last Updated"
+  sql_trigger: SELECT MAX(last_modified_time)
+    FROM `mozdata`.analysis.INFORMATION_SCHEMA.PARTITIONS
+    WHERE table_name = 'test_table_2' ;;
+  description: "Updates when mozdata:analysis.test_table_2 is modified."
+  max_cache_age: "24 hours"
+  interval_trigger: 6 hours
+}"""
+
+    views = [
+        TableView(
+            namespace="test_namespace",
+            name="table_1",
+            tables=[
+                {"table": "mozdata.analysis.test_table"},
+            ],
+        ),
+        TableView(
+            namespace="test_namespace",
+            name="table_2",
+            tables=[
+                {"table": "mozdata.analysis.test_table_2"},
+            ],
+        ),
+    ]
+
+    with runner.isolated_filesystem():
+        table_1.project = "mozdata"
+        table_2.project = "mozdata"
+        table_1.dataset_id = "analysis"
+        table_2.dataset_id = "analysis"
+        table_1.table_type = "TABLE"
+        table_2.table_type = "TABLE"
+        table_1.full_table_id = "mozdata:analysis.test_table"
+        table_2.full_table_id = "mozdata:analysis.test_table_2"
+        table_1.table_id = "test_table"
+        table_2.table_id = "test_table_2"
+        table_1.friendly_name = "Test Table"
+        table_2.friendly_name = "Test Table 2"
+        tables = {
+            "mozdata.analysis.test_table": table_1,
+            "mozdata.analysis.test_table_2": table_2,
+        }
+        client.get_table = tables.get
+
+        Path("looker-hub/test_namespace").mkdir(parents=True)
+        reference_map_mock.return_value = {}
+        generate_datagroups(
+            views,
+            target_dir=Path("looker-hub"),
+            namespace="test_namespace",
+            client=client,
+        )
+
+        assert Path("looker-hub/test_namespace/datagroups.lkml").exists()
+        assert Path("looker-hub/test_namespace/datagroups.lkml").read_text() == expected
+
+
+@patch("google.cloud.bigquery.Table")
+@patch("google.cloud.bigquery.Table")
+@patch("google.cloud.bigquery.Table")
+@patch("google.cloud.bigquery.Client")
+@patch("generator.views.lookml_utils.get_bigquery_view_reference_map")
+def test_generates_datagroups_with_tables_and_views(
+    reference_map_mock, client, table_1, view_1, view_1_source_table, runner
+):
+    expected = """# *Do not manually modify this file*
+
+# This file has been generated via https://github.com/mozilla/lookml-generator
+
+# Using a datagroup in an Explore: https://cloud.google.com/looker/docs/reference/param-explore-persist-with
+# Using a datagroup in a derived table: https://cloud.google.com/looker/docs/reference/param-view-datagroup-trigger
+
+datagroup: test_table_last_updated {
+  label: "Test Table Last Updated"
+  sql_trigger: SELECT MAX(last_modified_time)
+    FROM `mozdata`.analysis.INFORMATION_SCHEMA.PARTITIONS
+    WHERE table_name = 'test_table' ;;
+  description: "Updates when mozdata:analysis.test_table is modified."
+  max_cache_age: "24 hours"
+  interval_trigger: 6 hours
+}
+
+datagroup: view_1_source_last_updated {
+  label: "View Source Table Last Updated"
+  sql_trigger: SELECT MAX(last_modified_time)
+    FROM `moz-fx-data-shared-prod`.analysis.INFORMATION_SCHEMA.PARTITIONS
+    WHERE table_name = 'view_1_source' ;;
+  description: "Updates when moz-fx-data-shared-prod:analysis.view_1_source is modified."
+  max_cache_age: "24 hours"
+  interval_trigger: 6 hours
+}"""
+
+    views = [
+        TableView(
+            namespace="test_namespace",
+            name="table_1",
+            tables=[
+                {"table": "mozdata.analysis.test_table"},
+            ],
+        ),
+        TableView(
+            namespace="test_namespace",
+            name="test_view",
+            tables=[
+                {
+                    "table": "mozdata.analysis.view_1"
+                },  # View to moz-fx-data-shared-prod.analysis.view_1_source
+            ],
+        ),
+    ]
+
+    with runner.isolated_filesystem():
+        table_1.project = "mozdata"
+        table_1.dataset_id = "analysis"
+        table_1.table_type = "TABLE"
+        table_1.full_table_id = "mozdata:analysis.test_table"
+        table_1.table_id = "test_table"
+        table_1.friendly_name = "Test Table"
+
+        view_1.project = "mozdata"
+        view_1.dataset_id = "analysis"
+        view_1.table_type = "VIEW"
+        view_1.full_table_id = "mozdata:analysis.view_1"
+        view_1.table_id = "view_1"
+        view_1.friendly_name = "Test View"
+
+        view_1_source_table.project = "moz-fx-data-shared-prod"
+        view_1_source_table.dataset_id = "analysis"
+        view_1_source_table.table_type = "TABLE"
+        view_1_source_table.full_table_id = (
+            "moz-fx-data-shared-prod:analysis.view_1_source"
+        )
+        view_1_source_table.table_id = "view_1_source"
+        view_1_source_table.friendly_name = "View Source Table"
+
+        reference_map_mock.return_value = {
+            "analysis": {
+                "view_1": [["moz-fx-data-shared-prod", "analysis", "view_1_source"]]
+            }
+        }
+
+        tables = {
+            "mozdata.analysis.test_table": table_1,
+            "mozdata.analysis.view_1": view_1,
+            "moz-fx-data-shared-prod.analysis.view_1_source": view_1_source_table,
+        }
+        client.get_table = tables.get
+
+        Path("looker-hub/test_namespace").mkdir(parents=True)
+        generate_datagroups(
+            views,
+            target_dir=Path("looker-hub"),
+            namespace="test_namespace",
+            client=client,
+        )
+
+        assert Path("looker-hub/test_namespace/datagroups.lkml").exists()
+        assert Path("looker-hub/test_namespace/datagroups.lkml").read_text() == expected
+
+
+@patch("google.cloud.bigquery.Client")
+def test_skips_non_table_views(client, runner):
+
+    views = [
+        EventsView(
+            namespace="test_namespace",
+            name="test_event_view",
+            tables=[
+                {
+                    "events_table_view": "events_unnested_table",
+                    "base_table": "mozdata.glean_app.events_unnested",
+                },
+            ],
+        ),
+    ]
+
+    with runner.isolated_filesystem():
+        Path("looker-hub/test_namespace").mkdir(parents=True)
+        generate_datagroups(
+            views,
+            target_dir=Path("looker-hub"),
+            namespace="test_namespace",
+            client=client,
+        )
+
+        assert not Path("looker-hub/test_namespace/datagroups.lkml").exists()

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -11,7 +11,6 @@ import yaml
 from click.testing import CliRunner
 
 from generator.namespaces import (
-    _get_db_views,
     _get_explores,
     _get_glean_apps,
     _get_looker_views,
@@ -24,6 +23,7 @@ from generator.views import (
     GrowthAccountingView,
     TableView,
 )
+from generator.views.lookml_utils import get_bigquery_view_reference_map
 
 from .utils import print_and_test
 
@@ -500,7 +500,7 @@ def test_get_glean_apps(app_listings_uri, glean_apps):
 
 
 def test_get_looker_views(glean_apps, generated_sql_uri):
-    db_views = _get_db_views(generated_sql_uri)
+    db_views = get_bigquery_view_reference_map(generated_sql_uri)
     actual = _get_looker_views(glean_apps[0], db_views)
     namespace = glean_apps[0]["name"]
     expected = [
@@ -584,7 +584,7 @@ def test_get_funnel_view(glean_apps, tmp_path):
 
     sql_uri = paths_to_tar(dest, paths)
 
-    db_views = _get_db_views(sql_uri)
+    db_views = get_bigquery_view_reference_map(sql_uri)
     actual = _get_looker_views(glean_apps[0], db_views)
     namespace = glean_apps[0]["name"]
     expected = [
@@ -641,7 +641,7 @@ def test_get_funnel_explore(glean_apps, tmp_path):
 
     sql_uri = paths_to_tar(dest, paths)
 
-    db_views = _get_db_views(sql_uri)
+    db_views = get_bigquery_view_reference_map(sql_uri)
     views = _get_looker_views(glean_apps[0], db_views)
     actual = _get_explores(views)
     expected = {


### PR DESCRIPTION
Implementation of the [datagroup generation proposal](https://docs.google.com/document/d/1dPwa5KZnKHzYj3hULHy9unczCXugwr6rZHW1gveQ2fc/edit#heading=h.5x0d5h95i329), see also [DENG-676](https://mozilla-hub.atlassian.net/browse/DENG-676).

Split into a small refactor to use the generated-sql function, then datagroup generation with tests. 