### PR TITLE
Avoid repeating the same table multiple times for a view (DENG-690)

### DIFF
--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -30,7 +30,7 @@ class PingView(View):
         if (klass.allow_glean and not is_glean) or (not klass.allow_glean and is_glean):
             return
 
-        views = defaultdict(list)
+        view_tables: Dict[str, Dict[str, Dict[str, str]]] = defaultdict(dict)
         for channel in channels:
             dataset = channel["dataset"]
 
@@ -38,8 +38,8 @@ class PingView(View):
                 if view_id in OMIT_VIEWS:
                     continue
 
-                table: Dict[str, str] = {"table": f"mozdata.{dataset}.{view_id}"}
-
+                table_id = f"mozdata.{dataset}.{view_id}"
+                table: Dict[str, str] = {"table": table_id}
                 if channel.get("channel") is not None:
                     table["channel"] = channel["channel"]
 
@@ -53,10 +53,10 @@ class PingView(View):
                 ):
                     continue
 
-                views[view_id].append(table)
+                view_tables[view_id][table_id] = table
 
-        for view_id, tables in views.items():
-            yield klass(namespace, view_id, tables)
+        for view_id, tables_by_id in view_tables.items():
+            yield klass(namespace, view_id, list(tables_by_id.values()))
 
     @classmethod
     def from_dict(klass, namespace: str, name: str, _dict: ViewDict) -> PingView:

--- a/generator/views/table_view.py
+++ b/generator/views/table_view.py
@@ -29,7 +29,7 @@ class TableView(View):
         db_views: dict,
     ) -> Iterator[TableView]:
         """Get Looker views for a namespace."""
-        views = defaultdict(list)
+        view_tables: Dict[str, Dict[str, Dict[str, str]]] = defaultdict(dict)
         for channel in channels:
             dataset = channel["dataset"]
 
@@ -37,15 +37,15 @@ class TableView(View):
                 if view_id in OMIT_VIEWS:
                     continue
 
-                table: Dict[str, str] = {"table": f"mozdata.{dataset}.{view_id}"}
-
+                table_id = f"mozdata.{dataset}.{view_id}"
+                table: Dict[str, str] = {"table": table_id}
                 if "channel" in channel:
                     table["channel"] = channel["channel"]
 
-                views[view_id].append(table)
+                view_tables[view_id][table_id] = table
 
-        for view_id, tables in views.items():
-            yield TableView(namespace, f"{view_id}_table", tables)
+        for view_id, tables_by_id in view_tables.items():
+            yield TableView(namespace, f"{view_id}_table", list(tables_by_id.values()))
 
     @classmethod
     def from_dict(klass, namespace: str, name: str, _dict: ViewDict) -> TableView:


### PR DESCRIPTION
The same table was being repeated for a view if the Glean app had multiple release channels (due to the [special case logic which overrides the dataset for release channels](https://github.com/mozilla/lookml-generator/blob/09cdf4c404c07c4c5dc0ee8508646bce85f8e1ef/generator/namespaces.py#L202-L220)), which the `mozilla_vpn` app currently does after https://github.com/mozilla/probe-scraper/pull/552.  This resulted in unnecessary `channel` parameters being added to all the affected views.

This will hopefully resolve the errors in the VPN Looker views related to `channel` parameters/fields in [DENG-690](https://mozilla-hub.atlassian.net/browse/DENG-690) "_Various errors in looker-spoke-default_".

However, it doesn't address the fundamental complications involved:
- Some apps like `mozilla_vpn` will have multiple release channels, which should probably be handled in a better way.
- Some datasets like `mozilla_vpn` contain a mix of both Glean tables/views and non-Glean tables/views, but the current LookML generation logic just has a `glean_app` boolean setting at the namespace level.  We may need more granular settings for marking specific tables/views as Glean/non-Glean, or should perhaps avoid having a mix of Glean & non-Glean tables/views in the same dataset.