### PR TITLE
Only generate one datagroup per-table

### DIFF
--- a/generator/views/datagroups.py
+++ b/generator/views/datagroups.py
@@ -152,11 +152,13 @@ def generate_datagroups(
         DEFAULT_GENERATED_SQL_URI
     )
 
-    datagroup_content = [
-        lookml
-        for view in views
-        if (lookml := _generate_view_datagroup_lkml(view, client, dataset_view_map))
-    ]
+    datagroup_content = sorted(
+        set(
+            lookml
+            for view in views
+            if (lookml := _generate_view_datagroup_lkml(view, client, dataset_view_map))
+        )
+    )
 
     if datagroup_content:
         datagroups_lkml_path.write_text(FILE_HEADER + "\n\n".join(datagroup_content))


### PR DESCRIPTION
Some views reference the same table. For example `mozdata.org_mozilla_ios_klar.baseline_clients_daily` and `mozdata.org_mozilla_ios_klar.baseline_clients_first_seen` are both views to `moz-fx-data-shared-prod.org_mozilla_ios_klar_derived.baseline_clients_daily_v1`.

We only need a single datagroup generated in cases like this.