### PR TITLE
Fix unquoted interval_trigger subparameter

### DIFF
--- a/generator/views/datagroups.py
+++ b/generator/views/datagroups.py
@@ -1,6 +1,7 @@
 """Generate datagroup lkml files for each namespace."""
 
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
@@ -46,7 +47,10 @@ class Datagroup:
 
     def __str__(self) -> str:
         """Return the LookML string representation of a Datagroup."""
-        return lkml.dump({"datagroups": [self.__dict__]})  # type: ignore
+        datagroup_str = lkml.dump({"datagroups": [self.__dict__]})
+        return re.sub(
+            r"interval_trigger: (.+)", r'interval_trigger: "\1"', datagroup_str  # type: ignore
+        )
 
 
 def _get_datagroup_from_bigquery_table(table: bigquery.Table) -> Datagroup:

--- a/tests/test_datagroups.py
+++ b/tests/test_datagroups.py
@@ -42,7 +42,7 @@ datagroup: test_table_2_last_updated {
     WHERE table_name = 'test_table_2' ;;
   description: "Updates when mozdata:analysis.test_table_2 is modified."
   max_cache_age: "24 hours"
-  interval_trigger: 6 hours
+  interval_trigger: "6 hours"
 }
 
 datagroup: test_table_last_updated {
@@ -52,7 +52,7 @@ datagroup: test_table_last_updated {
     WHERE table_name = 'test_table' ;;
   description: "Updates when mozdata:analysis.test_table is modified."
   max_cache_age: "24 hours"
-  interval_trigger: 6 hours
+  interval_trigger: "6 hours"
 }"""
 
     views = [
@@ -126,7 +126,7 @@ datagroup: test_table_last_updated {
     WHERE table_name = 'test_table' ;;
   description: "Updates when mozdata:analysis.test_table is modified."
   max_cache_age: "24 hours"
-  interval_trigger: 6 hours
+  interval_trigger: "6 hours"
 }
 
 datagroup: view_1_source_last_updated {
@@ -136,7 +136,7 @@ datagroup: view_1_source_last_updated {
     WHERE table_name = 'view_1_source' ;;
   description: "Updates when moz-fx-data-shared-prod:analysis.view_1_source is modified."
   max_cache_age: "24 hours"
-  interval_trigger: 6 hours
+  interval_trigger: "6 hours"
 }"""
 
     views = [
@@ -257,7 +257,7 @@ datagroup: source_table_last_updated {
     WHERE table_name = 'source_table' ;;
   description: "Updates when moz-fx-data-shared-prod:analysis.source_table is modified."
   max_cache_age: "24 hours"
-  interval_trigger: 6 hours
+  interval_trigger: "6 hours"
 }"""
 
     views = [


### PR DESCRIPTION
`interval_trigger` seems to be unsupported in the `lkml` library. This is causing invalid lookml:
e.g. 
```
...
  max_cache_age: "24 hours"
  interval_trigger: 6 hours
```

I'll take a look upstream as well but this should fix it as well. 