### PR TITLE
Remove interval trigger from datagroup generation entirely

### DIFF
--- a/generator/views/datagroups.py
+++ b/generator/views/datagroups.py
@@ -1,7 +1,6 @@
 """Generate datagroup lkml files for each namespace."""
 
 import logging
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional

--- a/generator/views/datagroups.py
+++ b/generator/views/datagroups.py
@@ -15,7 +15,6 @@ from generator.views import TableView, View, lookml_utils
 from generator.views.lookml_utils import BQViewReferenceMap
 
 DEFAULT_MAX_CACHE_AGE = "24 hours"
-DEFAULT_INTERVAL_TRIGGER = "6 hours"
 
 # Note: INFORMATION_SCHEMA.PARTITIONS has a row with a `last_modified_time` value even for non-partitioned tables.
 SQL_TRIGGER_TEMPLATE = """
@@ -43,14 +42,10 @@ class Datagroup:
     sql_trigger: str
     description: str
     max_cache_age: str = DEFAULT_MAX_CACHE_AGE
-    interval_trigger: str = DEFAULT_INTERVAL_TRIGGER
 
     def __str__(self) -> str:
         """Return the LookML string representation of a Datagroup."""
-        datagroup_str = lkml.dump({"datagroups": [self.__dict__]})
-        return re.sub(
-            r"interval_trigger: (.+)", r'interval_trigger: "\1"', datagroup_str  # type: ignore
-        )
+        return lkml.dump({"datagroups": [self.__dict__]})  # type: ignore
 
 
 def _get_datagroup_from_bigquery_table(table: bigquery.Table) -> Datagroup:

--- a/tests/test_datagroups.py
+++ b/tests/test_datagroups.py
@@ -42,7 +42,6 @@ datagroup: test_table_2_last_updated {
     WHERE table_name = 'test_table_2' ;;
   description: "Updates when mozdata:analysis.test_table_2 is modified."
   max_cache_age: "24 hours"
-  interval_trigger: "6 hours"
 }
 
 datagroup: test_table_last_updated {
@@ -52,7 +51,6 @@ datagroup: test_table_last_updated {
     WHERE table_name = 'test_table' ;;
   description: "Updates when mozdata:analysis.test_table is modified."
   max_cache_age: "24 hours"
-  interval_trigger: "6 hours"
 }"""
 
     views = [
@@ -126,7 +124,6 @@ datagroup: test_table_last_updated {
     WHERE table_name = 'test_table' ;;
   description: "Updates when mozdata:analysis.test_table is modified."
   max_cache_age: "24 hours"
-  interval_trigger: "6 hours"
 }
 
 datagroup: view_1_source_last_updated {
@@ -136,7 +133,6 @@ datagroup: view_1_source_last_updated {
     WHERE table_name = 'view_1_source' ;;
   description: "Updates when moz-fx-data-shared-prod:analysis.view_1_source is modified."
   max_cache_age: "24 hours"
-  interval_trigger: "6 hours"
 }"""
 
     views = [
@@ -257,7 +253,6 @@ datagroup: source_table_last_updated {
     WHERE table_name = 'source_table' ;;
   description: "Updates when moz-fx-data-shared-prod:analysis.source_table is modified."
   max_cache_age: "24 hours"
-  interval_trigger: "6 hours"
 }"""
 
     views = [


### PR DESCRIPTION
I misinterpreted what the `interval_trigger` parameter does here. I though it was the interval between SQL triggers, but this is actually controlled by the maintenance schedule in the Admin panel: https://cloud.google.com/looker/docs/connecting-to-your-db#pdt_and_datagroup_maintenance_schedule. 

`interval_trigger` actually triggers the datagroup, so invalidates the cache for explores and/or triggers PDT rebuilds. 

PR removes interval triggers from datagroup definitions.