### PR TITLE
Search view type ping_view -> table_view

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -121,11 +121,11 @@ search:
   pretty_name: Search
   views:
     search_clients_engines_sources_daily:
-      type: ping_view
+      type: table_view
       tables:
         - table: mozdata.search.search_clients_engines_sources_daily
     mobile_search_clients_engines_sources_daily:
-      type: ping_view
+      type: table_view
       tables:
         - table: mozdata.search.mobile_search_clients_engines_sources_daily
     desktop_mobile_search_clients_monthly:


### PR DESCRIPTION
Doing this for 2 reasons: (1) currently datagroups only get generated for `table_view`'s and (2) these actually aren't ping tables. 

This will remove this measure:
```
  measure: clients {
    type: count_distinct
    sql: ${client_id} ;;
  }
```
from both hub views so we'll have to redefine it in the spoke. 

The corresponding explores are defined as ping explores:
```
  explores:
    desktop_search_counts:
      type: ping_explore
      views:
        base_view: search_clients_engines_sources_daily
    mobile_search_counts:
      type: ping_explore
      views:
        base_view: mobile_search_clients_engines_sources_daily
```
But these aren't ping tables, this makes me think there's a missing (auto-generated) Explore type here? I'm not actually sure why these explores were auto-generated. 