### PR TITLE
Bug 1823627 - Use a channel filter instead of a parameter switching out the table

### DIFF
--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -145,17 +145,13 @@ class Explore:
         channel_params = [
             param
             for _view_defn in self.get_view_lookml(view)["views"]
-            for param in _view_defn.get("parameters", [])
+            for param in _view_defn.get("filters", [])
             if _view_defn["name"] == view and param["name"] == "channel"
         ]
 
         if channel_params:
-            allowed_values = channel_params[0]["allowed_values"]
-            default_value = next(
-                (value for value in allowed_values if value["label"] == "Release"),
-                allowed_values[0],
-            )["value"]
-
+            allowed_values = channel_params[0]["suggestions"]
+            default_value = allowed_values[0]
             return escape_filter_expr(default_value)
         return None
 


### PR DESCRIPTION
The parameter switched out the underlying table to be queried. However we now have UNIONed tables for every variant of an application, making the first table contain data from all channels. Instead we now filter by `normalized_channel` and enforce that filter in explores.