### PR TITLE
Bug 1823627 - Use a channel filter instead of a parameter switching out the table

### DIFF
--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -145,17 +145,13 @@ class Explore:
         channel_params = [
             param
             for _view_defn in self.get_view_lookml(view)["views"]
-            for param in _view_defn.get("parameters", [])
+            for param in _view_defn.get("filters", [])
             if _view_defn["name"] == view and param["name"] == "channel"
         ]
 
         if channel_params:
-            allowed_values = channel_params[0]["allowed_values"]
-            default_value = next(
-                (value for value in allowed_values if value["label"] == "Release"),
-                allowed_values[0],
-            )["value"]
-
+            allowed_values = channel_params[0]["suggestions"]
+            default_value = allowed_values[0]
             return escape_filter_expr(default_value)
         return None
 

--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -92,25 +92,22 @@ class PingView(View):
             bq_client.get_table(table).schema, self.name
         )
 
-        # parameterize table name
-        if len(self.tables) > 1:
-            view_defn["parameters"] = [
+        # Round-tripping through a dict to get an ordered deduped list.
+        suggestions = list(dict.fromkeys(_table["channel"] for _table in self.tables))
+
+        if len(suggestions) > 1:
+            view_defn["filters"] = [
                 {
                     "name": "channel",
-                    "type": "unquoted",
-                    "default_value": table,
-                    "allowed_values": [
-                        {
-                            "label": _table["channel"].title(),
-                            "value": _table["table"],
-                        }
-                        for _table in self.tables
-                    ],
+                    "type": "string",
+                    "description": "Filter by the app's channel",
+                    "sql": "{% condition %} ${TABLE}.normalized_channel {% endcondition %}",
+                    "default_value": suggestions[0],
+                    "suggestions": suggestions,
                 }
             ]
-            view_defn["sql_table_name"] = "`{% parameter channel %}`"
-        else:
-            view_defn["sql_table_name"] = f"`{table}`"
+
+        view_defn["sql_table_name"] = f"`{table}`"
 
         return {"views": [view_defn] + nested_views}
 

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -889,24 +889,17 @@ def test_lookml_actual_baseline_view_parameterized(
             "views": [
                 {
                     "name": "baseline",
-                    "parameters": [
+                    "filters": [
                         {
                             "name": "channel",
-                            "type": "unquoted",
-                            "default_value": "mozdata.glean_app.baseline",
-                            "allowed_values": [
-                                {
-                                    "label": "Release",
-                                    "value": "mozdata.glean_app.baseline",
-                                },
-                                {
-                                    "label": "Beta",
-                                    "value": "mozdata.glean_app_beta.baseline",
-                                },
-                            ],
+                            "type": "string",
+                            "default_value": "release",
+                            "suggestions": ["release", "beta"],
+                            "description": "Filter by the app's channel",
+                            "sql": "{% condition %} ${TABLE}.normalized_channel {% endcondition %}",
                         }
                     ],
-                    "sql_table_name": "`{% parameter channel %}`",
+                    "sql_table_name": "`mozdata.glean_app.baseline`",
                     "dimensions": [
                         {
                             "name": "additional_properties",
@@ -1713,7 +1706,7 @@ def test_lookml_actual_baseline_explore(
                     "view_label": " Baseline",
                     "always_filter": {
                         "filters": [
-                            {"channel": "mozdata.glean^_app.baseline"},
+                            {"channel": "release"},
                             {"submission_date": "28 days"},
                         ]
                     },
@@ -1777,9 +1770,6 @@ def test_lookml_actual_client_counts(
                     "always_filter": {
                         "filters__all": [
                             [
-                                {
-                                    "channel": "mozdata.glean^_app.baseline^_clients^_daily"
-                                },
                                 {"submission_date": "28 days"},
                             ],
                         ],


### PR DESCRIPTION
The parameter switched out the underlying table to be queried. However we now have UNIONed tables for every variant of an application, making the first table contain data from all channels. Instead we now filter by `normalized_channel` and enforce that filter in explores.

---

I need to once more check that this now works as expected.