### PR TITLE
Add `table_explore` explore type

### DIFF
--- a/generator/explores/__init__.py
+++ b/generator/explores/__init__.py
@@ -10,6 +10,7 @@ from .operational_monitoring_explore import (
     OperationalMonitoringExplore,
 )
 from .ping_explore import PingExplore
+from .table_explore import TableExplore
 
 EXPLORE_TYPES = {
     ClientCountsExplore.type: ClientCountsExplore,
@@ -20,4 +21,5 @@ EXPLORE_TYPES = {
     GrowthAccountingExplore.type: GrowthAccountingExplore,
     OperationalMonitoringExplore.type: OperationalMonitoringExplore,
     OperationalMonitoringAlertingExplore.type: OperationalMonitoringAlertingExplore,
+    TableExplore.type: TableExplore,
 }

--- a/generator/explores/table_explore.py
+++ b/generator/explores/table_explore.py
@@ -1,0 +1,43 @@
+"""Table explore type."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+from google.cloud import bigquery
+
+from ..views import TableView, View
+from . import Explore
+
+
+class TableExplore(Explore):
+    """A table explore."""
+
+    type: str = "table_explore"
+
+    def _to_lookml(
+        self, client: bigquery.Client, v1_name: Optional[str]
+    ) -> List[Dict[str, Any]]:
+        """Generate LookML to represent this explore."""
+        explore_lookml: Dict[str, Any] = {
+            "name": self.name,
+            "view_name": self.views["base_view"],
+            "joins": self.get_unnested_fields_joins_lookml(),
+        }
+        if required_filters := self.get_required_filters("base_view"):
+            explore_lookml["always_filter"] = {
+                "filters": required_filters,
+            }
+        return [explore_lookml]
+
+    @staticmethod
+    def from_views(views: List[View]) -> Iterator[TableExplore]:
+        """Generate all possible TableExplores from the views."""
+        for view in views:
+            if view.view_type == TableView.type:
+                yield TableExplore(view.name, {"base_view": view.name})
+
+    @staticmethod
+    def from_dict(name: str, defn: dict, views_path: Path) -> TableExplore:
+        """Get an instance of this explore from a name and dictionary definition."""
+        return TableExplore(name, defn["views"], views_path)


### PR DESCRIPTION
Intended to be used with `table_view`  views, to avoid having to create boilerplate explores in looker-spoke-default.