### PR TITLE
Add `subscription_platform` namespace to expose existing ETL tables (DS-2934)

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1108,3 +1108,36 @@ hubs:
       type: table_view
       tables:
         - table: mozdata.hubs.active_subscription_ids
+subscription_platform:
+  pretty_name: Subscription Platform
+  owners:
+    - srose@mozilla.com
+  glean_app: false
+  views:
+    # Using `_v1` views to avoid breakages when v2 tables are deployed.
+    apple_subscriptions_v1:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.subscription_platform_derived.apple_subscriptions_v1
+    google_subscriptions_v1:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.subscription_platform_derived.google_subscriptions_v1
+    stripe_subscriptions_v1:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_v1
+  explores:
+    # Using `_v1` explores to avoid breakages when v2 tables are deployed.
+    apple_subscriptions_v1:
+      type: table_explore
+      views:
+        base_view: apple_subscriptions_v1
+    google_subscriptions_v1:
+      type: table_explore
+      views:
+        base_view: google_subscriptions_v1
+    stripe_subscriptions_v1:
+      type: table_explore
+      views:
+        base_view: stripe_subscriptions_v1


### PR DESCRIPTION
## [DS-2934](https://mozilla-hub.atlassian.net/browse/DS-2934): Make current SubPlat ETLs available as Looker explores

This is a stopgap solution to support SubPlat’s metrics reporting until the new ETLs are completed.