### PR TITLE
RS 733 - Create public ctx srvcs namespace

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -155,7 +155,7 @@ search:
       type: ping_explore
       views:
         base_view: desktop_search_alert_records
-contextual_services:
+contextual_services_private:
   glean_app: false
   connection: bigquery-oauth
   pretty_name: Contextual Services
@@ -268,6 +268,19 @@ contextual_services:
       type: ping_explore
       views:
         base_view: topsites_impression_firefox_ios
+contextual_services:
+  glean_app: false
+  connection: bigquery-oauth
+  pretty_name: Contextual Services
+  owners:
+    - mmccorquodale@mozilla.com
+    - rburwei@mozilla.com
+    - mbowerman@mozilla.com
+  views:
+    sponsored_tiles_ad_request_fill:
+      type: table_view
+      tables:
+        - table: mozdata.telemetry.sponsored_tiles_ad_request_fill
 mozilla_vpn_private:
   glean_app: false
   connection: bigquery-oauth

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -270,7 +270,6 @@ contextual_services_private:
         base_view: topsites_impression_firefox_ios
 contextual_services:
   glean_app: false
-  connection: bigquery-oauth
   pretty_name: Contextual Services
   owners:
     - mmccorquodale@mozilla.com


### PR DESCRIPTION
Relates to https://mozilla-hub.atlassian.net/browse/RS-733. 
1. Rename `contextual_services` to `contextual_services_private` (spoke remains `looker-spoke-private`)
2. Add new namespace `contextual_services` which is defaulted to public.
Note - the `pretty_name` will remain `Contextual Services` for both namespaces
3. Add the fill rate `mozdata view` to the public namespace. 

