### PR TITLE
Allow `table_view` measures to be defined in `custom-namespaces.yaml`

### DIFF
--- a/generator/views/view.py
+++ b/generator/views/view.py
@@ -8,6 +8,7 @@ from click import ClickException
 OMIT_VIEWS: Set[str] = set()
 
 
+# TODO: Once we upgrade to Python 3.11 mark just `measures` as non-required, not all keys.
 class ViewDict(TypedDict, total=False):
     """Represent a view definition."""
 

--- a/generator/views/view.py
+++ b/generator/views/view.py
@@ -8,11 +8,12 @@ from click import ClickException
 OMIT_VIEWS: Set[str] = set()
 
 
-class ViewDict(TypedDict):
+class ViewDict(TypedDict, total=False):
     """Represent a view definition."""
 
     type: str
     tables: List[Dict[str, str]]
+    measures: Dict[str, Dict[str, Any]]
 
 
 class View(object):


### PR DESCRIPTION
Example:
```yaml
foo_namespace:
  views:
    bar_table:
      type: table_view
      tables:
        - table: ...
      measures:
        count:
          type: count
        client_count:
          type: count_distinct
          sql: client_id
```

