### PR TITLE
Add count measures to SubPlat table views (DS-2934)

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1131,14 +1131,23 @@ subscription_platform:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.subscription_platform_derived.apple_subscriptions_v1
+      measures:
+        count:
+          type: count
     google_subscriptions_v1:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.subscription_platform_derived.google_subscriptions_v1
+      measures:
+        count:
+          type: count
     stripe_subscriptions_v1:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_v1
+      measures:
+        count:
+          type: count
   explores:
     # Using `_v1` explores to avoid breakages when v2 tables are deployed.
     apple_subscriptions_v1:


### PR DESCRIPTION
## [DS-2934](https://mozilla-hub.atlassian.net/browse/DS-2934): Make current SubPlat ETLs available as Looker explores

This is a follow-up to #684.