### PR TITLE
Move includes in spoke model generation to footer comment.

### DIFF
--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -83,7 +83,7 @@ def generate_model(
 
     path = spoke_path / name / f"{name}.model.lkml"
     # lkml.dump may return None, in which case write an empty file
-    header_text = f"""
+    footer_text = f"""
 # Include files from looker-hub or spoke-default below. For example:
 # include: "//looker-hub/{name}/explores/*"
 # include: "//looker-hub/{name}/dashboards/*"
@@ -96,7 +96,7 @@ def generate_model(
     if model_text is None:
         path.write_text("")
     else:
-        path.write_text(header_text + model_text)
+        path.write_text(model_text + footer_text)
 
     return path
 

--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -79,18 +79,24 @@ def generate_model(
     model_defn = {
         "connection": db_connection,
         "label": namespace_defn["pretty_name"],
-        "includes": [
-            f"//looker-hub/{name}/explores/*",
-            f"//looker-hub/{name}/dashboards/*",
-            "views/*",
-            "explores/*",
-            "dashboards/*",
-        ],
     }
 
     path = spoke_path / name / f"{name}.model.lkml"
     # lkml.dump may return None, in which case write an empty file
-    path.write_text(lkml.dump(model_defn) or "")
+    header_text = f"""
+# Include files from looker-hub or spoke-default below. For example:
+# include: "//looker-hub/{name}/explores/*"
+# include: "//looker-hub/{name}/dashboards/*"
+# include: "//looker-hub/{name}/views/*"
+# include: "views/*"
+# include: "explores/*"
+# include: "dashboards/*"
+"""
+    model_text = lkml.dump(model_defn)
+    if model_text is None:
+        path.write_text("")
+    else:
+        path.write_text(header_text + model_text)
 
     return path
 

--- a/tests/test_spoke.py
+++ b/tests/test_spoke.py
@@ -137,7 +137,8 @@ def test_generate_model(looker_sdk, namespaces, tmp_path):
         "label": "Glean App",
     }
 
-    expected_text = '''
+    expected_text = """connection: "telemetry"
+label: "Glean App"
 # Include files from looker-hub or spoke-default below. For example:
 # include: "//looker-hub/glean-app/explores/*"
 # include: "//looker-hub/glean-app/dashboards/*"
@@ -145,8 +146,7 @@ def test_generate_model(looker_sdk, namespaces, tmp_path):
 # include: "views/*"
 # include: "explores/*"
 # include: "dashboards/*"
-connection: "telemetry"
-label: "Glean App"'''
+"""
     actual_text = (
         tmp_path / "looker-spoke-default" / "glean-app" / "glean-app.model.lkml"
     ).read_text()
@@ -188,7 +188,8 @@ def test_alternate_connection(looker_sdk, custom_namespaces, tmp_path):
         "connection": "bigquery-oauth",
         "label": "Custom",
     }
-    expected_text = '''
+    expected_text = """connection: "bigquery-oauth"
+label: "Custom"
 # Include files from looker-hub or spoke-default below. For example:
 # include: "//looker-hub/custom/explores/*"
 # include: "//looker-hub/custom/dashboards/*"
@@ -196,8 +197,7 @@ def test_alternate_connection(looker_sdk, custom_namespaces, tmp_path):
 # include: "views/*"
 # include: "explores/*"
 # include: "dashboards/*"
-connection: "bigquery-oauth"
-label: "Custom"'''
+"""
     actual_text = (
         tmp_path / "looker-spoke-private" / "custom" / "custom.model.lkml"
     ).read_text()

--- a/tests/test_spoke.py
+++ b/tests/test_spoke.py
@@ -132,23 +132,27 @@ def test_generate_model(looker_sdk, namespaces, tmp_path):
     looker_sdk.models.WriteModelSet.return_value = write_model
 
     generate_directories(namespaces, tmp_path, True)
-    expected = {
+    expected_dict = {
         "connection": "telemetry",
         "label": "Glean App",
-        "includes": [
-            "//looker-hub/glean-app/explores/*",
-            "//looker-hub/glean-app/dashboards/*",
-            "views/*",
-            "explores/*",
-            "dashboards/*",
-        ],
     }
-    actual = lkml.load(
-        (
-            tmp_path / "looker-spoke-default" / "glean-app" / "glean-app.model.lkml"
-        ).read_text()
-    )
-    assert expected == actual
+
+    expected_text = '''
+# Include files from looker-hub or spoke-default below. For example:
+# include: "//looker-hub/glean-app/explores/*"
+# include: "//looker-hub/glean-app/dashboards/*"
+# include: "//looker-hub/glean-app/views/*"
+# include: "views/*"
+# include: "explores/*"
+# include: "dashboards/*"
+connection: "telemetry"
+label: "Glean App"'''
+    actual_text = (
+        tmp_path / "looker-spoke-default" / "glean-app" / "glean-app.model.lkml"
+    ).read_text()
+    actual_dict = lkml.load(actual_text)
+    assert expected_text == actual_text
+    assert expected_dict == actual_dict
 
     looker_sdk.models.WriteModelSet.assert_any_call(models=["model", "glean-app"])
     assert looker_sdk.models.WriteModelSet.call_count == 1
@@ -180,21 +184,26 @@ def test_alternate_connection(looker_sdk, custom_namespaces, tmp_path):
         app_path / "custom.model.lkml",
     }
 
-    expected = {
+    expected_dict = {
         "connection": "bigquery-oauth",
         "label": "Custom",
-        "includes": [
-            "//looker-hub/custom/explores/*",
-            "//looker-hub/custom/dashboards/*",
-            "views/*",
-            "explores/*",
-            "dashboards/*",
-        ],
     }
-    actual = lkml.load(
-        (tmp_path / "looker-spoke-private" / "custom" / "custom.model.lkml").read_text()
-    )
-    print_and_test(expected, actual)
+    expected_text = '''
+# Include files from looker-hub or spoke-default below. For example:
+# include: "//looker-hub/custom/explores/*"
+# include: "//looker-hub/custom/dashboards/*"
+# include: "//looker-hub/custom/views/*"
+# include: "views/*"
+# include: "explores/*"
+# include: "dashboards/*"
+connection: "bigquery-oauth"
+label: "Custom"'''
+    actual_text = (
+        tmp_path / "looker-spoke-private" / "custom" / "custom.model.lkml"
+    ).read_text()
+    actual_dict = lkml.load(actual_text)
+    print_and_test(expected_text, actual_text)
+    print_and_test(expected_dict, actual_dict)
 
     looker_sdk.models.WriteLookmlModel.assert_called_with(
         allowed_db_connection_names=["bigquery-oauth"],


### PR DESCRIPTION
By default, spoke-default PRs (e.g. https://github.com/mozilla/looker-spoke-default/pull/563) that create models auto-generate includes to a number of directories (as well as create empty directories). It seems like pointing to the empty created directories no longer prevents LookML warnings. One way to solve this is by manually editing the PR to comment out or remove the includes that won't have content. 

This PR automatically generates the includes as comments so merging by default won't break the production spokes. 