### PR TITLE
Add table views for Stripe products and plans (DENG-1448)

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1248,6 +1248,14 @@ subscription_platform:
         count_sum:
           type: sum
           sql: ${count}
+    stripe_plans:
+      type: table_view
+      tables:
+        - table: mozdata.subscription_platform.stripe_plans
+    stripe_products:
+      type: table_view
+      tables:
+        - table: mozdata.subscription_platform.stripe_products
     # Logical subscriptions
     logical_subscriptions:
       type: table_view


### PR DESCRIPTION
## [DENG-1448](https://mozilla-hub.atlassian.net/browse/DENG-1448): Add Stripe product and plan data to the Firefox Accounts > All Event Counts explore

mozilla/bigquery-etl#4234 will need to be merged and deployed first.