### PR TITLE
Take 2: Add urlbar events to Looker

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -741,11 +741,6 @@ firefox_desktop:
       tables:
         - table: mozdata.default_browser_agent.default_browser
   explores:
-    urlbar_event_counts:
-      type: events_explore
-      views:
-        base_view: urlbar_events
-        extended_view: urlbar_events_table
     client_counts:
       type: client_counts_explore
       views:

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -741,7 +741,7 @@ firefox_desktop:
       tables:
         - table: mozdata.default_browser_agent.default_browser
   explores:
-    urlbar_events:
+    urlbar_event_counts:
       type: events_explore
       views:
         base_view: urlbar_events


### PR DESCRIPTION
Fixing the name of the explore so it doesn't conflict with the names of existing explores. 

Why I think this will fix it: https://github.com/mozilla/lookml-generator/blob/main/generator/explores/events_explore.py#L40