### PR TITLE
Add explore for gplay data

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -40,7 +40,25 @@ duet:
   owners:
     - ascholtz@mozilla.com
   pretty_name: DUET
+  explores:
+    type: table_explore
+    views:
+      base_view: gplay_installs_by_country
   views:
+    gplay_installs_by_country:
+      type: table_view
+      tables:
+        - table: mozdata.fenix.gplay_installs_by_country
+      measures:
+        total_installs:
+          type: sum
+          sql: "${install_count}"
+        total_uninstalls:
+          type: sum
+          sql: "${uninstall_count}"
+        total_updates:
+          type: sum
+          sql: "${update_count}"
     install:
       type: ping_view
       tables:


### PR DESCRIPTION
I'm pretty sure this should work. The lkml library [adds semicolons to SQL statements](https://github.com/joshtemple/lkml/issues/51), so we don't need to add those to the measure definitions.

note: I wrote this manually in the Github editor, so lmk if you see something off in the yaml.