### PR TITLE
Remove invalid link properties from datetime metric dimension groups in Glean ping views

### DIFF
--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -311,6 +311,8 @@ class GleanPingView(PingView):
             # Dimension groups should not be nested (see issue #82).
             del lookml["group_label"]
             del lookml["group_item_label"]
+            # Links are not supported for dimension groups.
+            del lookml["links"]
 
         # remove some elements from the definition if we're handling a labeled
         # counter, as an initial join dimension

--- a/tests/test_glean_ping_view.py
+++ b/tests/test_glean_ping_view.py
@@ -184,6 +184,7 @@ def test_datetime_metric(mock_glean_ping):
     assert "timeframes" in lookml["views"][0]["dimension_groups"][0]
     assert "group_label" not in lookml["views"][0]["dimension_groups"][0]
     assert "group_item_label" not in lookml["views"][0]["dimension_groups"][0]
+    assert "links" not in lookml["views"][0]["dimension_groups"][0]
 
 
 @patch("generator.views.glean_ping_view.GleanPing")


### PR DESCRIPTION
LookML validation is failing with `Invalid property for "dimension_group": link` errors for the 106 current such datetime metric dimension groups.