### PR TITLE
COUNT(DISTINCT ${TABLE}.client_id) in client count views

### DIFF
--- a/generator/views/client_counts_view.py
+++ b/generator/views/client_counts_view.py
@@ -63,7 +63,7 @@ class ClientCountsView(View):
             "type": "number",
             "description": "The number of clients, "
             "determined by whether they sent a baseline ping on the day in question.",
-            "sql": "COUNT(DISTINCT client_id)",
+            "sql": "COUNT(DISTINCT ${TABLE}.client_id)",
         }
     ]
 


### PR DESCRIPTION
I've ran into some issues where joining the Client Counts view with other views that had a `client_id` field raised `Column name client_id is ambiguous`