### PR TITLE
Add desktop acquisition funnel sample table to start dashboard layout

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -704,6 +704,10 @@ experimentation:
 firefox_desktop:
   glean_app: true
   views:
+    desktop_acquisition_funnel_table:
+      type: table_view
+      tables:
+        - table: mozdata.analysis.gkabbz_sample_desktop_funnel
     urlbar_events_table:
       type: table_view
       tables:


### PR DESCRIPTION
Add desktop acquisition funnel sample table to start dashboarding. Will be replaced by permanent view once available. Metrics should stay the same but will likely have additional dimensions.