### PR TITLE
Generate view for `stripe_subscriptions_v2` (DS-3079)

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1393,6 +1393,10 @@ subscription_platform:
       measures:
         count:
           type: count
+    stripe_subscriptions:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_v2
     active_subscriptions:
       type: table_view
       tables:


### PR DESCRIPTION
## [DS-3079](https://mozilla-hub.atlassian.net/browse/DS-3079): Stripe subscriptions Looker explores

This generates a view for the new `stripe_subscriptions_v2` table.

Depends on mozilla/bigquery-etl#4712.