### PR TITLE
1866834 - adding new view on use counter data to combined_browser_met…

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -35,6 +35,10 @@ combined_browser_metrics:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.telemetry.cohort_daily_statistics
+    fenix_and_firefox_use_counters:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.telemetry.fenix_and_firefox_use_counters
 review_checker_desktop:
   glean_app: false
   owners:


### PR DESCRIPTION
Bugzilla 1866834 - Adding a new view to combined_browser_metrics, on top of GCP view: 
moz-fx-data-shared-prod.telemetry.fenix_and_firefox_use_counters