### PR TITLE
Fix handling event stream tables

### DIFF
--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -125,6 +125,7 @@ def _generate_dimensions(client: bigquery.Client, table: str) -> List[Dict[str, 
             and name != "submission"
             and not name.endswith("end")
             and not name.endswith("start")
+            and not (name != "event" and dimension["type"] != "time")
         ):
             raise click.ClickException(
                 f"duplicate dimension {name!r} for table {table!r}"


### PR DESCRIPTION
The newly added events stream tables have a string field `event` and an `event_timestamp` field. `event_timestamp` should be handled similar to submission_timestamp.

Currently lookml-generator is failing with `Error: duplicate dimension 'event' for table 'mozdata.org_mozilla_fenix.events_stream'`