### PR TITLE
Adding 7 new GA4 tables to looker

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1296,19 +1296,19 @@ websites:
     ga4_www_site_downloads:
       type: table_view
       tables:
-      - table: moz-fx-data-marketing-prod.ga_derived.www_site_downloads_v2
+        - table: moz-fx-data-marketing-prod.ga_derived.www_site_downloads_v2
     ga4_sessions:
       type: table_view
       tables: 
-      - table: moz-fx-data-shared-prod.mozilla_org_derived.ga_sessions_v2
+        - table: moz-fx-data-shared-prod.mozilla_org_derived.ga_sessions_v2
     ga4_www_site_hits:
       type: table_view
       tables: 
-      - table: moz-fx-data-marketing-prod.ga_derived.www_site_hits_v2
+        - table: moz-fx-data-marketing-prod.ga_derived.www_site_hits_v2
     ga4_moz_org_page_metrics:
       type: table_view
       tables:
-      - table: moz-fx-data-marketing-prod.ga_derived.www_site_page_metrics_v2
+        - table: moz-fx-data-marketing-prod.ga_derived.www_site_page_metrics_v2
     moz_org_page_metrics:
       type: table_view
       tables:
@@ -1316,7 +1316,7 @@ websites:
     ga4_moz_org_metrics_summary:
       type: table_view
       tables:
-      - table: moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v2
+        - table: moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v2
     moz_org_metrics_summary:
       type: table_view
       tables:
@@ -1324,7 +1324,7 @@ websites:
     ga4_moz_org_landing_page_metrics:
       type: table_view
       tables:
-      - table: moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics_v2
+        - table: moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics_v2
     moz_org_landing_page_metrics:
       type: table_view
       tables:
@@ -1340,7 +1340,7 @@ websites:
     ga4_www_site_events_metrics: 
       type: table_view
       tables:
-      - table: moz-fx-data-marketing-prod.ga_derived.www_site_events_metrics_v2
+        - table: moz-fx-data-marketing-prod.ga_derived.www_site_events_metrics_v2
     www_site_events_metrics:
       type: table_view
       tables:

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1339,6 +1339,7 @@ websites:
         - table: moz-fx-data-marketing-prod.ga_derived.blogs_landing_page_summary_v1
     ga4_www_site_events_metrics: 
       type: table_view
+      tables:
       - table: moz-fx-data-marketing-prod.ga_derived.www_site_events_metrics_v2
     www_site_events_metrics:
       type: table_view

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1293,14 +1293,38 @@ websites:
   owners:
     - kignasiak@mozilla.com
   views:
+    ga4_www_site_downloads:
+      type: table_view
+      tables:
+      - table: moz-fx-data-marketing-prod.ga_derived.www_site_downloads_v2
+    ga4_sessions:
+      type: table_view
+      tables: 
+      - table: moz-fx-data-shared-prod.mozilla_org_derived.ga_sessions_v2
+    ga4_www_site_hits:
+      type: table_view
+      tables: 
+      - table: moz-fx-data-marketing-prod.ga_derived.www_site_hits_v2
+    ga4_moz_org_page_metrics:
+      type: table_view
+      tables:
+      - table: moz-fx-data-marketing-prod.ga_derived.www_site_page_metrics_v2
     moz_org_page_metrics:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.ga_derived.www_site_page_metrics_v1
+    ga4_moz_org_metrics_summary:
+      type: table_view
+      tables:
+      - table: moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v2
     moz_org_metrics_summary:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v1
+    ga4_moz_org_landing_page_metrics:
+      type: table_view
+      tables:
+      - table: moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v2
     moz_org_landing_page_metrics:
       type: table_view
       tables:
@@ -1313,6 +1337,9 @@ websites:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.ga_derived.blogs_landing_page_summary_v1
+    ga4_www_site_events_metrics: 
+      type: table_view
+      - table: moz-fx-data-marketing-prod.ga_derived.www_site_events_metrics_v2
     www_site_events_metrics:
       type: table_view
       tables:

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1324,7 +1324,7 @@ websites:
     ga4_moz_org_landing_page_metrics:
       type: table_view
       tables:
-      - table: moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v2
+      - table: moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics_v2
     moz_org_landing_page_metrics:
       type: table_view
       tables:


### PR DESCRIPTION
**Added 7 new views in the websites folder:**
- ga4_www_site_downloads: moz-fx-data-marketing-prod.ga_derived.www_site_downloads_v2
- ga4_sessions: moz-fx-data-shared-prod.mozilla_org_derived.ga_sessions_v2
- ga4_www_site_hits: moz-fx-data-marketing-prod.ga_derived.www_site_hits_v2
- ga4_moz_org_page_metrics: moz-fx-data-marketing-prod.ga_derived.www_site_page_metrics_v2
- ga4_moz_org_metrics_summary: moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v2
- ga4_moz_org_landing_page_metrics: moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics_v2
- ga4_www_site_events_metrics: moz-fx-data-marketing-prod.ga_derived.www_site_events_metrics_v2