### PR TITLE
Glean ping explores with nested dimensions

### DIFF
--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -1,4 +1,5 @@
 """Class to describe a Glean Ping View."""
+
 import logging
 import re
 from collections import Counter
@@ -9,6 +10,7 @@ import click
 from mozilla_schema_generator.glean_ping import GleanPing
 from mozilla_schema_generator.probes import GleanProbe
 
+from . import lookml_utils
 from .lookml_utils import slug_to_title
 from .ping_view import PingView
 
@@ -177,7 +179,11 @@ class GleanPingView(PingView):
             {v["name"]: v for v in view_definitions}.values(), key=lambda x: x["name"]  # type: ignore
         )
 
-        lookml["views"] += view_definitions
+        nested_views = lookml_utils._generate_nested_dimension_views(
+            bq_client.get_table(table).schema, self.name
+        )
+
+        lookml["views"] += view_definitions + nested_views
 
         return lookml
 

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -1612,6 +1612,27 @@ def test_lookml_actual_metric_definitions_view(
                     ],
                     "name": "suggest__metrics__metrics__labeled_counter__test_labeled_counter_not_in_source",
                 },
+                {
+                    "dimensions": [
+                        {"name": "key", "sql": "${TABLE}.key", "type": "string"},
+                        {"name": "value", "sql": "${TABLE}.value", "type": "number"},
+                    ],
+                    "name": "metrics__metrics__custom_distribution__test_custom_distribution__values",
+                },
+                {
+                    "dimensions": [
+                        {"name": "key", "sql": "${TABLE}.key", "type": "string"},
+                        {"name": "value", "sql": "${TABLE}.value", "type": "number"},
+                    ],
+                    "name": "metrics__metrics__memory_distribution__test_memory_distribution__values",
+                },
+                {
+                    "dimensions": [
+                        {"name": "key", "sql": "${TABLE}.key", "type": "string"},
+                        {"name": "value", "sql": "${TABLE}.value", "type": "number"},
+                    ],
+                    "name": "metrics__metrics__timing_distribution__test_timing_distribution__values",
+                },
             ]
         }
         print_and_test(


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-2802

Nested dimensions are currently not available in Glean ping explores. This PR adds them.
We already have them in some other explore types.

After merging, [this PR](https://github.com/mozilla/looker-spoke-default/pull/751) also needs to be merged since it manually adds `experiments` for messaging system

Generated lookml is here: https://github.com/mozilla/looker-hub/compare/main...glean-explores-with-nested-dimensions