### PR TITLE
[DENG-1908] Auto-import existing explores for new namespaces

### DIFF
--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -81,11 +81,14 @@ def generate_model(
         "label": namespace_defn["pretty_name"],
     }
 
+    # automatically import generated explores for new glean apps
+    has_explores = len(namespace_defn.get("explores", {})) > 0
+
     path = spoke_path / name / f"{name}.model.lkml"
     # lkml.dump may return None, in which case write an empty file
     footer_text = f"""
 # Include files from looker-hub or spoke-default below. For example:
-# include: "//looker-hub/{name}/explores/*"
+{'' if has_explores else '# '}include: "//looker-hub/{name}/explores/*"
 # include: "//looker-hub/{name}/dashboards/*"
 # include: "//looker-hub/{name}/views/*"
 # include: "views/*"

--- a/tests/test_spoke.py
+++ b/tests/test_spoke.py
@@ -135,12 +135,13 @@ def test_generate_model(looker_sdk, namespaces, tmp_path):
     expected_dict = {
         "connection": "telemetry",
         "label": "Glean App",
+        "includes": ["//looker-hub/glean-app/explores/*"],
     }
 
     expected_text = """connection: "telemetry"
 label: "Glean App"
 # Include files from looker-hub or spoke-default below. For example:
-# include: "//looker-hub/glean-app/explores/*"
+include: "//looker-hub/glean-app/explores/*"
 # include: "//looker-hub/glean-app/dashboards/*"
 # include: "//looker-hub/glean-app/views/*"
 # include: "views/*"


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-1908

This uncomments the explore import for new namespaces added to looker-spoke if explores exist, e.g. the generated ones for glean apps.  @akkomar Is there value in doing this for existing custom namespaces that have explores added?  I think it's reasonable to expect someone to update the spoke repo along with adding explores here.

No new test cases because the existing ones already cover both cases.