### PR TITLE
chore(): Removing duplicate configuration for firefox ios / android clients table

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -177,10 +177,6 @@ duet:
       type: table_view
       tables:
         - table: mozdata.firefox_ios.app_store_funnel
-    firefox_android_clients:
-      type: table_view
-      tables:
-        - table: mozdata.fenix.firefox_android_clients
 activity_stream:
   glean_app: false
   owners:
@@ -702,10 +698,6 @@ firefox_ios:
       type: table_explore
       views:
         base_view: clients_activation
-    firefox_ios_clients:
-      type: table_explore
-      views:
-        base_view: firefox_ios_clients
 fenix:
   pretty_name: Firefox Android
   owners:
@@ -748,10 +740,6 @@ fenix:
       type: table_explore
       views:
         base_view: feature_usage_events
-    firefox_android_clients:
-      type: table_explore
-      views:
-        base_view: firefox_android_clients
 focus_ios:
   owners:
     - loines@mozilla.com


### PR DESCRIPTION
# chore(): Removing duplicate configuration for firefox ios / android clients table

This is to avoid the same table view to be generated multiple times.

follow-up: https://github.com/mozilla/looker-spoke-default/pull/759