### PR TITLE
Remove `urlbar_clients_daily` from Looker

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -850,17 +850,6 @@ awesome_bar:
   glean_app: false
   owners:
     - ascholtz@mozilla.com
-  pretty_name: Awesome Bar
-  views:
-    urlbar_clients_daily:
-      type: ping_view
-      tables:
-        - table: mozdata.telemetry.urlbar_clients_daily
-  explores:
-    urlbar_clients_daily:
-      type: ping_explore
-      views:
-        base_view: urlbar_clients_daily
 experimentation:
   glean_app: false
   owners:

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -846,10 +846,6 @@ newtab:
     - cmorales@mozilla.com
     - mbowerman@mozilla.com
   spoke: looker-spoke-private
-awesome_bar:
-  glean_app: false
-  owners:
-    - ascholtz@mozilla.com
 experimentation:
   glean_app: false
   owners:


### PR DESCRIPTION
The underlying table has been marked for deprecate via https://github.com/mozilla/bigquery-etl/pull/5046 so we should update Looker to remove the table from the Explore

