### PR TITLE
Add Monitor Frontend to custom-namespaces.yaml

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -457,7 +457,7 @@ monitor_frontend:
     - ksiegler@mozilla.com
   pretty_name: Monitor Frontend
   views:
-      dashboard_user_journey_funnels:
+    dashboard_user_journey_funnels:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.monitor_frontend_derived.monitor_dashboard_user_journey_funnels_v1

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -451,6 +451,21 @@ mozilla_vpn:
       tables:
         - channel: release
           table: mozdata.mozilla_vpn.vat_rates
+monitor_frontend:
+  glean_app: true
+  owners:
+    - ksiegler@mozilla.com
+  pretty_name: Monitor Frontend
+  views:
+      dashboard_user_journey_funnels:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.monitor_frontend_derived.monitor_dashboard_user_journey_funnels_v1
+  explores:
+      dashboard_user_journey_funnels:
+      type: table_explore
+      views:
+        base_view: dashboard_user_journey_funnels
 firefox_accounts:
   glean_app: false
   owners:

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -462,7 +462,7 @@ monitor_frontend:
       tables:
         - table: moz-fx-data-shared-prod.monitor_frontend_derived.monitor_dashboard_user_journey_funnels_v1
   explores:
-      dashboard_user_journey_funnels:
+    dashboard_user_journey_funnels:
       type: table_explore
       views:
         base_view: dashboard_user_journey_funnels


### PR DESCRIPTION
@scholtzan the Explores in the Monitor Frontend folder that currently exist are Glean data, but the funnel data I added here is not. I set `glean_app: true` since it's technically based on Glean. Is this okay?