### PR TITLE
Remove deprecated glean apps

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1611,3 +1611,24 @@ telemetry_dev_cycle:
       type: table_view
       tables:
         - table: mozdata.telemetry_dev_cycle.telemetry_probes_stats
+growth:
+  pretty_name: Growth
+  owners:
+    - fbertsch@mozilla.com
+    - kik@mozilla.com
+  glean_app: false
+mr_2022:
+  pretty_name: MR 2022
+  owners:
+    - loines@mozilla.com
+  glean_app: false
+user_journey:
+  pretty_name: User Journey
+  owners:
+    - fbertsch@mozilla.com
+  glean_app: false
+pocket_snowflake:
+  pretty_name: Pocket Snowflake
+  owners:
+    - mhirose@mozilla.com
+  glean_app: false

--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import shutil
+from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, TypedDict
 
@@ -149,13 +150,10 @@ def generate_directories(
     namespaces: Dict[str, NamespaceDict], base_dir: Path, sdk_setup=False
 ):
     """Generate directories and model for a namespace, if it doesn't exist."""
-    seen_spoke_namespaces = {}
+    seen_spoke_namespaces = defaultdict(list)
     for namespace, defn in namespaces.items():
         spoke = defn["spoke"]
-        if spoke not in seen_spoke_namespaces:
-            seen_spoke_namespaces[spoke] = [namespace]
-        else:
-            seen_spoke_namespaces[spoke].append(namespace)
+        seen_spoke_namespaces[spoke].append(namespace)
 
         spoke_dir = base_dir / spoke
         spoke_dir.mkdir(parents=True, exist_ok=True)
@@ -186,10 +184,11 @@ def generate_directories(
 
         for existing_dir in existing_dirs:
             # make sure the directory belongs to a namespace by checking if a model file exists
-            if Path(existing_dir / f"{existing_dir}.model.lkml").is_file():
+            if (spoke_dir / existing_dir / f"{existing_dir}.model.lkml").is_file():
                 if existing_dir not in seen_spoke_namespaces[spoke]:
                     # namespace does not exists anymore, remove directory
-                    shutil.rmtree(Path(existing_dir))
+                    print(f"Removing {existing_dir} from {spoke_dir}")
+                    shutil.rmtree(spoke_dir / existing_dir)
 
 
 @click.command(help=__doc__)

--- a/generator/spoke.py
+++ b/generator/spoke.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import shutil
 from pathlib import Path
 from typing import Dict, List, TypedDict
 
@@ -148,8 +149,14 @@ def generate_directories(
     namespaces: Dict[str, NamespaceDict], base_dir: Path, sdk_setup=False
 ):
     """Generate directories and model for a namespace, if it doesn't exist."""
+    seen_spoke_namespaces = {}
     for namespace, defn in namespaces.items():
         spoke = defn["spoke"]
+        if spoke not in seen_spoke_namespaces:
+            seen_spoke_namespaces[spoke] = [namespace]
+        else:
+            seen_spoke_namespaces[spoke].append(namespace)
+
         spoke_dir = base_dir / spoke
         spoke_dir.mkdir(parents=True, exist_ok=True)
         print(f"Writing {namespace} to {spoke_dir}")
@@ -171,6 +178,18 @@ def generate_directories(
             sdk = looker_sdk.init40()
             logging.info("Looker SDK 4.0 initialized successfully.")
             configure_model(sdk, namespace, db_connection, spoke_project)
+
+    # remove directories for namespaces that got removed
+    for spoke in seen_spoke_namespaces.keys():
+        spoke_dir = base_dir / spoke
+        existing_dirs = {p.name for p in spoke_dir.iterdir()}
+
+        for existing_dir in existing_dirs:
+            # make sure the directory belongs to a namespace by checking if a model file exists
+            if Path(existing_dir / f"{existing_dir}.model.lkml").is_file():
+                if existing_dir not in seen_spoke_namespaces[spoke]:
+                    # namespace does not exists anymore, remove directory
+                    shutil.rmtree(Path(existing_dir))
 
 
 @click.command(help=__doc__)

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -14,3 +14,5 @@
 - tiktokreporter_*
 - org_mozilla_ios_tiktok_reporter*
 - org_mozilla_tiktokreporter
+- moso_*
+- regrets_reporter


### PR DESCRIPTION
Looker artifacts for deprecated Glean apps are automatically removed from looker-hub via: https://github.com/mozilla/lookml-generator/blob/fdf36bb0e1ee52078176c562031467ce12d28b39/generator/namespaces.py#L257
We should also remove the corresponding folders in the spoke projects, which is what this PR does.

The folders will be removed as part of the auto-push PRs ([such as this one](https://github.com/mozilla/looker-spoke-default/pull/790)). 

This is part of the effort to remove content from Looker to speed things up