### PR TITLE
Remove Looker artifacts for namespaces that haven't been used in the last 360 days

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -139,15 +139,7 @@ function setup_spokes() {
 }
 
 function check_files_and_commit() {
-  # Check that base branch files are unchanged. Error if they are.
   # Add the new files and commit.
-
-  if ! git diff-index --quiet HEAD;
-  then
-    git diff-index HEAD | cut -f 2 | xargs -I % echo "Error: lookml-generator modified %"
-    exit 1
-  fi
-
   # Use interactive mode to add untracked files
   # This also works when it's untracked directories
   echo -e "a\n*\nq\n"|git add -i

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1233,21 +1233,6 @@ monitoring:
       type: ping_explore
       views:
         base_view: telemetry_missing_columns
-accessibility:
-  glean_app: false
-  owners:
-    - mreschenberg@mozilla.com
-  pretty_name: Accessibility
-  views:
-    accessibility_clients:
-      type: ping_view
-      tables:
-        - table: mozdata.telemetry.accessibility_clients
-  explores:
-    accessibility_clients:
-      type: ping_explore
-      views:
-        base_view: accessibility_clients
 casa:
   glean_app: false
   spoke: looker-spoke-private

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -16,3 +16,9 @@
 - org_mozilla_tiktokreporter
 - moso_*
 - regrets_reporter
+- mozphab
+- mozregression
+- pine
+- treeherder
+- sync
+- mozillavpn_backend_cirrus


### PR DESCRIPTION
It doesn't seem like these have been used or aren't used anymore, so we can remove the Looker content to speed up things a little