### PR TITLE
Speeding up Looker - remove unnecessary, duplicate views in custom namespaces yaml

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -436,11 +436,6 @@ mozilla_vpn:
       tables:
         - channel: release
           table: mozdata.mozilla_vpn.site_metrics_summary_v2
-    ga4_site_metrics_summary:
-      type: table_view
-      tables:
-        - channel: release
-          table: mozdata.mozilla_vpn.site_metrics_summary_v2
     subscriptions:
       type: table_view
       tables:
@@ -1316,30 +1311,14 @@ websites:
       type: table_view
       tables: 
         - table: moz-fx-data-shared-prod.mozilla_org.ga_sessions_v2
-    ga4_www_site_hits:
-      type: table_view
-      tables: 
-        - table: moz-fx-data-marketing-prod.ga.www_site_hits
-    ga4_moz_org_page_metrics:
-      type: table_view
-      tables:
-        - table: moz-fx-data-marketing-prod.ga.www_site_page_metrics
     moz_org_page_metrics:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.ga.www_site_page_metrics
-    ga4_moz_org_metrics_summary:
-      type: table_view
-      tables:
-        - table: moz-fx-data-marketing-prod.ga.www_site_metrics_summary
     moz_org_metrics_summary:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.ga.www_site_metrics_summary
-    ga4_moz_org_landing_page_metrics:
-      type: table_view
-      tables:
-        - table: moz-fx-data-marketing-prod.ga.www_site_landing_page_metrics
     moz_org_landing_page_metrics:
       type: table_view
       tables:
@@ -1356,31 +1335,15 @@ websites:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.ga.blogs_daily_summary
-    ga4_blogs_daily_summary:
-      type: table_view
-      tables:
-        - table: moz-fx-data-marketing-prod.ga.blogs_daily_summary
     blogs_landing_page_summary:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.ga.blogs_landing_page_summary
-    ga4_blogs_landing_page_summary:
-      type: table_view
-      tables:
-        - table: moz-fx-data-marketing-prod.ga.blogs_landing_page_summary
-    ga4_www_site_events_metrics: 
-      type: table_view
-      tables:
-        - table: moz-fx-data-marketing-prod.ga.www_site_events_metrics
     www_site_events_metrics:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.ga.www_site_events_metrics
     firefox_whatsnew_summary:
-      type: table_view
-      tables:
-        - table: moz-fx-data-marketing-prod.ga.firefox_whatsnew_summary
-    ga4_firefox_whatsnew_summary:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.ga.firefox_whatsnew_summary


### PR DESCRIPTION
During the GA3 -> GA4 migration, we had both GA3 and GA4 tables in custom namespaces YAML.  When we switched over to GA4, we found it easiest to just switch the existing GA3 tables to the new GA4 tables.  So now that the migration is done, want to clean up so we don't waste space/slow down Looker by having 2 copies of the same tables with different names.  Removing the ones that are unused and keeping the ones with downstream dependencies.