### PR TITLE
Remove Cirrus apps

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -24,3 +24,4 @@
 - mozillavpn_backend_cirrus
 - glean_dictionary
 - mach
+- "*_cirrus"


### PR DESCRIPTION
As discussed with the Nimbus data leads, we don't need this data in Looker