### PR TITLE
Rename Google Search Console views (DENG-1733)

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1347,11 +1347,11 @@ websites:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.ga.firefox_whatsnew_summary
-    google_search_impressions_by_page:
+    google_search_console_by_page:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.google_search_console.search_impressions_by_page
-    google_search_impressions_by_site:
+    google_search_console_by_site:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.google_search_console.search_impressions_by_site


### PR DESCRIPTION
## [DENG-1733](https://mozilla-hub.atlassian.net/browse/DENG-1733): Make Google Search Console data available for use

Renaming the `google_search_impressions_*` views `google_search_console_*` as requested by the stakeholder.

https://github.com/mozilla/looker-spoke-default/pull/819 should be merged soon after this is merged to minimize LookML breakage.