### PR TITLE
Update custom-namespaces.yaml with additional login funnels

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -555,6 +555,18 @@ firefox_accounts:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.firefox_accounts_derived.login_funnels_by_service_v1
+    login_funnels_email_confirmation_by_service:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.firefox_accounts_derived.login_funnels_email_confirmation_by_service_v1
+    login_funnels_submit_by_service:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.firefox_accounts_derived.login_funnels_submit_by_service_v1
+    login_funnels_two_factor_by_service:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.firefox_accounts_derived.login_funnels_two_factor_by_service_v1
     registration_funnels_by_service:
       type: table_view
       tables:
@@ -656,6 +668,18 @@ firefox_accounts:
       type: table_explore
       views:
         base_view: login_funnels_by_service
+    login_funnels_email_conformation_by_service:
+      type: table_explore
+      views:
+        base_view: login_funnels_email_confirmation_by_service
+    login_funnels_submit_by_service:
+      type: table_explore
+      views:
+        base_view: login_funnels_submit_by_service
+    login_funnels_two_factor_by_service:
+      type: table_explore
+      views:
+        base_view: login_funnels_two_factor_by_service
     registration_funnels_by_service:
       type: table_explore
       views:


### PR DESCRIPTION
Creating Explores for the new login funnels. Removing the null flow IDs may have allowed me to put all of these into one config file and Explore, so if that's preferred I can make that change.