### PR TITLE
Update metric definition views to depend on data source joins

### DIFF
--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -165,29 +165,6 @@ def _get_metric_hub_namespaces(existing_namespaces):
                 "type": "metric_definitions_view"
             }
 
-            if (
-                namespace in existing_namespaces
-                and "client_counts" in existing_namespaces[namespace]["views"]
-            ):
-                views[f"metric_definitions_{data_source}"]["tables"] = [
-                    {
-                        "table": existing_namespaces[namespace]["views"][
-                            "client_counts"
-                        ]["tables"][0]["table"]
-                    }
-                ]
-            elif (
-                namespace in existing_namespaces
-                and "baseline_clients_daily" in existing_namespaces[namespace]["views"]
-            ):
-                views[f"metric_definitions_{data_source}"]["tables"] = [
-                    {
-                        "table": existing_namespaces[namespace]["views"][
-                            "baseline_clients_daily"
-                        ]["tables"][0]["table"]
-                    }
-                ]
-
             explores[f"metric_definitions_{data_source}"] = {
                 "type": "metric_definitions_explore",
                 "views": {"base_view": f"metric_definitions_{data_source}"},

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ google-cloud-storage==2.16.0
 Jinja2==3.1.4
 lkml==1.3.4
 looker-sdk==24.8.0
-mozilla-metric-config-parser==2024.4.1
+mozilla-metric-config-parser==2024.5.2
 mozilla-nimbus-schemas==2023.10.23
 mozilla-schema-generator==0.5.1
 pandas==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -453,9 +453,9 @@ mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
     # via flake8
-mozilla-metric-config-parser==2024.4.1 \
-    --hash=sha256:a10908bce94fd24445ade474cc671a09c0241d2a456de84b69bc7e67eb67bbd1 \
-    --hash=sha256:eb3cbb526f37f9fa455d534a21fe85464beae890443e40b5989d8104e18a8b9f
+mozilla-metric-config-parser==2024.5.2 \
+    --hash=sha256:4c8f718bfac3c6e72fc4edff5c0d6af80881d6108f6c0224fb9ed3f262970a74 \
+    --hash=sha256:67f759f64fe12705be1020329d023aa5a8d3de4425fb2b9258d4477aa59ad936
     # via -r requirements.in
 mozilla-nimbus-schemas==2023.10.23 \
     --hash=sha256:84ddebf89d99754442676dc379c7eccc76de9adc13cbf8942ead85d8a6cde540 \


### PR DESCRIPTION
Depends on https://github.com/mozilla/metric-config-parser/pull/367 and https://github.com/mozilla/metric-config-parser/pull/366

Instead of having "Metric Definition" explores joined to "Client Count" explores to make them filterable, these changes allow to configure a data source in metric-hub to be used to provide these base fields. Metric hub now allows `joins` expressions between data sources