### PR TITLE
Update dataset in custom-namespaces for login and registration funnels

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -554,11 +554,11 @@ firefox_accounts:
     login_funnels_by_service:
       type: table_view
       tables:
-        - table: moz-fx-data-shared-prod.firefox_accounts_derived.login_funnels_by_service_v1
+        - table: moz-fx-data-shared-prod.accounts_frontend_derived.login_funnels_by_service_v1
     registration_funnels_by_service:
       type: table_view
       tables:
-        - table: moz-fx-data-shared-prod.firefox_accounts_derived.registration_funnels_by_service_v1
+        - table: moz-fx-data-shared-prod.accounts_frontend_derived.registration_funnels_by_service_v1
     registration_funnels:
       type: table_view
       tables:


### PR DESCRIPTION
Updating dataset ID for registration and login funnels after moving them to `accounts_frontend_derived` for consistency.