### PR TITLE
Generate suggest explores only for specific labeled counters

### DIFF
--- a/tests/test_glean_ping_view.py
+++ b/tests/test_glean_ping_view.py
@@ -226,4 +226,4 @@ def test_undeployed_probe(mock_glean_ping):
     # view. Expect 3 views, because 1 for the table view, 2 added for fun.counter_metric
     # because it's in the table schema, and 0 added for fun.counter_metric2 because it's
     # not in the table schema.
-    assert len(lookml["views"]) == 3
+    assert len(lookml["views"]) == 2


### PR DESCRIPTION
Running [Henry](https://github.com/looker-open-source/henry) on our Looker instance indicated that there are over 1200 unused explores all related to the generated `suggest__` explores that are provided for each labeled counter. The only suggest explores that have been used are for the `glean_error_invalid_label` dimensions.

This PR changes the generation logic to only generate suggest explores for specific labeled counters and removes all the unused suggest explores. This should increase platform performance.