### PR TITLE
Update Google Search Console views to use BigQuery views in `mozdata`

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1358,11 +1358,11 @@ websites:
     google_search_console_by_page:
       type: table_view
       tables:
-        - table: moz-fx-data-marketing-prod.google_search_console.search_impressions_by_page
+        - table: mozdata.google_search_console.search_impressions_by_page
     google_search_console_by_site:
       type: table_view
       tables:
-        - table: moz-fx-data-marketing-prod.google_search_console.search_impressions_by_site
+        - table: mozdata.google_search_console.search_impressions_by_site
 marketing:
   glean_app: false
   pretty_name: Marketing


### PR DESCRIPTION
Because the BigQuery views are being moved (mozilla/bigquery-etl#5822).