### PR TITLE
Use dry run function for generation

### DIFF
--- a/generator/__init__.py
+++ b/generator/__init__.py
@@ -6,17 +6,36 @@
 
 __docformat__ = "restructuredtext"
 
+import sys
 import warnings
 
 import click
+from google.auth.exceptions import DefaultCredentialsError
+from google.cloud import bigquery
 
 from .lookml import lookml
 from .namespaces import namespaces
 from .spoke import update_spoke
 
 
+def is_authenticated():
+    """Check if the user is authenticated to GCP."""
+    try:
+        bigquery.Client()
+    except DefaultCredentialsError:
+        return False
+    return True
+
+
 def cli(prog_name=None):
     """Generate and run CLI."""
+    if not is_authenticated():
+        print(
+            "Authentication to GCP required. Run `gcloud auth login --update-adc` "
+            "and check that the project is set correctly."
+        )
+        sys.exit(1)
+
     commands = {
         "namespaces": namespaces,
         "lookml": lookml,

--- a/generator/dashboards/dashboard.py
+++ b/generator/dashboards/dashboard.py
@@ -29,6 +29,6 @@ class Dashboard(object):
             }
         }
 
-    def to_lookml(self, client):
+    def to_lookml(self):
         """Generate Lookml for this dashboard."""
         raise NotImplementedError("Only implemented in subclass.")

--- a/generator/dashboards/operational_monitoring_dashboard.py
+++ b/generator/dashboards/operational_monitoring_dashboard.py
@@ -54,7 +54,7 @@ class OperationalMonitoringDashboard(Dashboard):
         ]
         return {branch: color for branch, color in zip(branches, colours)}
 
-    def to_lookml(self, bq_client):
+    def to_lookml(self):
         """Get this dashboard as LookML."""
         kwargs = {
             "name": self.name,

--- a/generator/dryrun.py
+++ b/generator/dryrun.py
@@ -36,11 +36,12 @@ def id_token():
 class DryRunError(Exception):
     """Exception raised on dry run errors."""
 
-    def __init__(self, message, error, use_cloud_function):
+    def __init__(self, message, error, use_cloud_function, table_id):
         """Initialize DryRunError."""
         super().__init__(message)
         self.error = error
         self.use_cloud_function = use_cloud_function
+        self.table_id = table_id
 
 
 class Errors(Enum):
@@ -160,7 +161,10 @@ class DryRun:
         """Return the query schema by dry running the SQL file."""
         if not self.is_valid():
             raise DryRunError(
-                "Error when dry running SQL", self.get_error(), self.use_cloud_function
+                "Error when dry running SQL",
+                self.get_error(),
+                self.use_cloud_function,
+                self.table,
             )
 
         if (
@@ -176,7 +180,10 @@ class DryRun:
         """Return the schema of the provided table."""
         if not self.is_valid():
             raise DryRunError(
-                "Error when dry running SQL", self.get_error(), self.use_cloud_function
+                "Error when dry running SQL",
+                self.get_error(),
+                self.use_cloud_function,
+                self.table,
             )
 
         if (
@@ -192,7 +199,10 @@ class DryRun:
         """Return table metadata."""
         if not self.is_valid():
             raise DryRunError(
-                "Error when dry running SQL", self.get_error(), self.use_cloud_function
+                "Error when dry running SQL",
+                self.get_error(),
+                self.use_cloud_function,
+                self.table,
             )
 
         if (
@@ -255,6 +265,9 @@ class DryRun:
                 in error_message
             ):
                 return Errors.DATE_FILTER_NEEDED_AND_SYNTAX
-            if "Permission bigquery.tables.get denied on table" in error_message:
+            if (
+                "Permission bigquery.tables.get denied on table" in error_message
+                or "User does not have permission to query table" in error_message
+            ):
                 return Errors.PERMISSION_DENIED
         return None

--- a/generator/dryrun.py
+++ b/generator/dryrun.py
@@ -1,0 +1,218 @@
+from google.cloud import bigquery
+from google.auth.exceptions import DefaultCredentialsError
+import google.auth
+from google.auth.transport.requests import Request as GoogleAuthRequest
+from google.cloud import bigquery
+from google.oauth2.id_token import fetch_id_token
+from urllib.request import Request, urlopen
+import json
+from functools import cached_property
+from enum import Enum
+from typing import Optional
+
+import sys
+
+DRY_RUN_URL = (
+    "https://us-central1-moz-fx-data-shared-prod.cloudfunctions.net/bigquery-etl-dryrun"
+)
+
+
+def is_authenticated():
+    """Check if the user is authenticated to GCP."""
+    try:
+        bigquery.Client(project="")
+    except DefaultCredentialsError:
+        return False
+    return True
+
+
+class Errors(Enum):
+    """DryRun errors that require special handling."""
+
+    READ_ONLY = 1
+    DATE_FILTER_NEEDED = 2
+    DATE_FILTER_NEEDED_AND_SYNTAX = 3
+
+
+class DryRun:
+    """Dry run SQL."""
+
+    def __init__(
+        self,
+        sql=None,
+        use_cloud_function=True,
+        client=None,
+        project=None,
+        dataset=None,
+        table=None,
+        dry_run_url=DRY_RUN_URL,
+    ):
+        self.sql = sql
+        self.use_cloud_function = use_cloud_function
+        self.client = client if use_cloud_function or client else bigquery.Client()
+        self.project = project
+        self.dataset = dataset
+        self.table = table
+        self.dry_run_url = dry_run_url
+
+        if not is_authenticated():
+            print(
+                "Authentication to GCP required. Run `gcloud auth login  --update-adc` "
+                "and check that the project is set correctly."
+            )
+            sys.exit(1)
+
+    @cached_property
+    def dry_run_result(self):
+        try:
+            if self.use_cloud_function:
+                auth_req = GoogleAuthRequest()
+                creds, _ = google.auth.default(
+                    scopes=["https://www.googleapis.com/auth/cloud-platform"]
+                )
+                creds.refresh(auth_req)
+                if hasattr(creds, "id_token"):
+                    # Get token from default credentials for the current environment created via Cloud SDK run
+                    id_token = creds.id_token
+                else:
+                    # If the environment variable GOOGLE_APPLICATION_CREDENTIALS is set to service account JSON file,
+                    # then ID token is acquired using this service account credentials.
+                    id_token = fetch_id_token(auth_req, self.dry_run_url)
+
+                json_data = {
+                    "query": self.sql,
+                    "project": self.project,
+                    "dataset": self.dataset,
+                    "table": self.table,
+                }
+
+                r = urlopen(
+                    Request(
+                        self.dry_run_url,
+                        headers={
+                            "Content-Type": "application/json",
+                            "Authorization": f"Bearer {id_token}",
+                        },
+                        data=json.dumps(json_data).encode("utf8"),
+                        method="POST",
+                    )
+                )
+                return json.load(r)
+            else:
+                if self.project:
+                    self.client.project = self.project
+
+                job_config = bigquery.QueryJobConfig(
+                    dry_run=True,
+                    use_query_cache=False,
+                    query_parameters=[
+                        bigquery.ScalarQueryParameter(
+                            "submission_date", "DATE", "2019-01-01"
+                        )
+                    ],
+                )
+                job = self.client.query(self.sql, job_config=job_config)
+                try:
+                    dataset_labels = self.client.get_dataset(job.default_dataset).labels
+                except Exception as e:
+                    # Most users do not have bigquery.datasets.get permission in
+                    # moz-fx-data-shared-prod
+                    # This should not prevent the dry run from running since the dataset
+                    # labels are usually not required
+                    if "Permission bigquery.datasets.get denied on dataset" in str(e):
+                        dataset_labels = []
+                    else:
+                        raise e
+
+                return {
+                    "valid": True,
+                    "referencedTables": [
+                        ref.to_api_repr() for ref in job.referenced_tables
+                    ],
+                    "schema": (
+                        job._properties.get("statistics", {})
+                        .get("query", {})
+                        .get("schema", {})
+                    ),
+                    "datasetLabels": dataset_labels,
+                }
+        except Exception as e:
+            print(f"ERROR {e}")
+            return None
+
+    def get_schema(self):
+        """Return the query schema by dry running the SQL file."""
+        if not self.is_valid():
+            raise Exception(f"Error when dry running SQL")
+
+        if (
+            self.dry_run_result
+            and self.dry_run_result["valid"]
+            and "schema" in self.dry_run_result
+        ):
+            return self.dry_run_result["schema"]
+
+        return {}
+
+    def get_table_schema(self):
+        """Return the schema of the provided table."""
+        if not self.is_valid():
+            raise Exception(f"Error when dry running SQL")
+
+        if (
+            self.dry_run_result
+            and self.dry_run_result["valid"]
+            and "tableSchema" in self.dry_run_result
+        ):
+            return self.dry_run_result["tableSchema"]
+
+        return {}
+
+    def is_valid(self):
+        """Dry run the provided SQL file and check if valid."""
+        if self.dry_run_result is None:
+            return False
+
+        if self.dry_run_result["valid"]:
+            print(f"OK")
+        elif self.get_error() == Errors.READ_ONLY:
+            # We want the dryrun service to only have read permissions, so
+            # we expect CREATE VIEW and CREATE TABLE to throw specific
+            # exceptions.
+            print(f"OK")
+        elif self.get_error() == Errors.DATE_FILTER_NEEDED:
+            # With strip_dml flag, some queries require a partition filter
+            # (submission_date, submission_timestamp, etc.) to run
+            # We mark these requests as valid and add a date filter
+            # in get_referenced_table()
+            print(f"OK but DATE FILTER NEEDED")
+        else:
+            print(f"ERROR\n", self.dry_run_result["errors"])
+            return False
+
+        return True
+
+    def get_error(self) -> Optional[Errors]:
+        """Get specific errors for edge case handling."""
+        errors = self.errors()
+        if len(errors) != 1:
+            return None
+
+        error = errors[0]
+        if error and error.get("code") in [400, 403]:
+            error_message = error.get("message", "")
+            if (
+                "does not have bigquery.tables.create permission for dataset"
+                in error_message
+                or "Permission bigquery.tables.create denied" in error_message
+                or "Permission bigquery.datasets.update denied" in error_message
+            ):
+                return Errors.READ_ONLY
+            if "without a filter over column(s)" in error_message:
+                return Errors.DATE_FILTER_NEEDED
+            if (
+                "Syntax error: Expected end of input but got keyword WHERE"
+                in error_message
+            ):
+                return Errors.DATE_FILTER_NEEDED_AND_SYNTAX
+        return None

--- a/generator/dryrun.py
+++ b/generator/dryrun.py
@@ -1,16 +1,19 @@
-from google.cloud import bigquery
-from google.auth.exceptions import DefaultCredentialsError
+"""Dry Run method to get BigQuery metadata."""
+
+import io
+import json
+import os
+import sys
+from enum import Enum
+from functools import cached_property
+from typing import Optional
+from urllib.request import Request, urlopen
+
 import google.auth
+from google.auth.exceptions import DefaultCredentialsError
 from google.auth.transport.requests import Request as GoogleAuthRequest
 from google.cloud import bigquery
 from google.oauth2.id_token import fetch_id_token
-from urllib.request import Request, urlopen
-import json
-from functools import cached_property
-from enum import Enum
-from typing import Optional
-
-import sys
 
 DRY_RUN_URL = (
     "https://us-central1-moz-fx-data-shared-prod.cloudfunctions.net/bigquery-etl-dryrun"
@@ -20,7 +23,7 @@ DRY_RUN_URL = (
 def is_authenticated():
     """Check if the user is authenticated to GCP."""
     try:
-        bigquery.Client(project="")
+        bigquery.Client()
     except DefaultCredentialsError:
         return False
     return True
@@ -40,14 +43,16 @@ class DryRun:
     def __init__(
         self,
         sql=None,
-        use_cloud_function=True,
+        use_cloud_function=os.getenv("USE_CLOUD_FUNCTION", "False").lower()
+        in ("true", "1", "t"),
         client=None,
         project=None,
         dataset=None,
         table=None,
         dry_run_url=DRY_RUN_URL,
     ):
-        self.sql = sql
+        """Initialize dry run instance."""
+        self.sql = sql or "SELECT 1"
         self.use_cloud_function = use_cloud_function
         self.client = client if use_cloud_function or client else bigquery.Client()
         self.project = project
@@ -64,6 +69,7 @@ class DryRun:
 
     @cached_property
     def dry_run_result(self):
+        """Return the dry run result."""
         try:
             if self.use_cloud_function:
                 auth_req = GoogleAuthRequest()
@@ -102,39 +108,70 @@ class DryRun:
                 if self.project:
                     self.client.project = self.project
 
-                job_config = bigquery.QueryJobConfig(
-                    dry_run=True,
-                    use_query_cache=False,
-                    query_parameters=[
-                        bigquery.ScalarQueryParameter(
-                            "submission_date", "DATE", "2019-01-01"
-                        )
-                    ],
-                )
-                job = self.client.query(self.sql, job_config=job_config)
-                try:
-                    dataset_labels = self.client.get_dataset(job.default_dataset).labels
-                except Exception as e:
-                    # Most users do not have bigquery.datasets.get permission in
-                    # moz-fx-data-shared-prod
-                    # This should not prevent the dry run from running since the dataset
-                    # labels are usually not required
-                    if "Permission bigquery.datasets.get denied on dataset" in str(e):
-                        dataset_labels = []
-                    else:
-                        raise e
+                query_schema = None
+                referenced_tables = []
+                dataset_labels = []
+                table_schema = None
+                table_metadata = None
 
-                return {
-                    "valid": True,
-                    "referencedTables": [
-                        ref.to_api_repr() for ref in job.referenced_tables
-                    ],
-                    "schema": (
+                if self.sql:
+                    job_config = bigquery.QueryJobConfig(
+                        dry_run=True,
+                        use_query_cache=False,
+                        query_parameters=[
+                            bigquery.ScalarQueryParameter(
+                                "submission_date", "DATE", "2019-01-01"
+                            )
+                        ],
+                    )
+                    job = self.client.query(self.sql, job_config=job_config)
+                    query_schema = (
                         job._properties.get("statistics", {})
                         .get("query", {})
                         .get("schema", {})
-                    ),
+                    )
+                    referenced_tables = [
+                        ref.to_api_repr() for ref in job.referenced_tables
+                    ]
+
+                if self.dataset is not None:
+                    try:
+                        dataset_labels = self.client.get_dataset(self.dataset).labels
+                    except Exception as e:
+                        # Most users do not have bigquery.datasets.get permission in
+                        # moz-fx-data-shared-prod
+                        # This should not prevent the dry run from running since the dataset
+                        # labels are usually not required
+                        if "Permission bigquery.datasets.get denied on dataset" in str(
+                            e
+                        ):
+                            dataset_labels = []
+                        else:
+                            raise e
+
+                if (
+                    self.project is not None
+                    and self.table is not None
+                    and self.dataset is not None
+                ):
+                    table = self.client.get_table(
+                        f"{self.project}.{self.dataset}.{self.table}"
+                    )
+                    s = io.StringIO("")
+                    self.client.schema_to_json(table.schema, s)
+                    table_schema = json.loads(s.getvalue())
+                    table_metadata = {
+                        "tableType": table.table_type,
+                        "friendlyName": table.friendly_name,
+                        "schema": table_schema,
+                    }
+
+                return {
+                    "valid": True,
+                    "referencedTables": referenced_tables,
+                    "schema": query_schema,
                     "datasetLabels": dataset_labels,
+                    "tableMetadata": table_metadata,
                 }
         except Exception as e:
             print(f"ERROR {e}")
@@ -143,7 +180,7 @@ class DryRun:
     def get_schema(self):
         """Return the query schema by dry running the SQL file."""
         if not self.is_valid():
-            raise Exception(f"Error when dry running SQL")
+            raise Exception("Error when dry running SQL")
 
         if (
             self.dry_run_result
@@ -157,14 +194,28 @@ class DryRun:
     def get_table_schema(self):
         """Return the schema of the provided table."""
         if not self.is_valid():
-            raise Exception(f"Error when dry running SQL")
+            raise Exception("Error when dry running SQL")
 
         if (
             self.dry_run_result
             and self.dry_run_result["valid"]
-            and "tableSchema" in self.dry_run_result
+            and "tableMetadata" in self.dry_run_result
         ):
-            return self.dry_run_result["tableSchema"]
+            return self.dry_run_result["tableMetadata"]["schema"]
+
+        return {}
+
+    def get_table_metadata(self):
+        """Return table metadata."""
+        if not self.is_valid():
+            raise Exception("Error when dry running SQL")
+
+        if (
+            self.dry_run_result
+            and self.dry_run_result["valid"]
+            and "tableMetadata" in self.dry_run_result
+        ):
+            return self.dry_run_result["tableMetadata"]
 
         return {}
 
@@ -174,23 +225,27 @@ class DryRun:
             return False
 
         if self.dry_run_result["valid"]:
-            print(f"OK")
+            return True
         elif self.get_error() == Errors.READ_ONLY:
             # We want the dryrun service to only have read permissions, so
             # we expect CREATE VIEW and CREATE TABLE to throw specific
             # exceptions.
-            print(f"OK")
+            return True
         elif self.get_error() == Errors.DATE_FILTER_NEEDED:
             # With strip_dml flag, some queries require a partition filter
             # (submission_date, submission_timestamp, etc.) to run
             # We mark these requests as valid and add a date filter
             # in get_referenced_table()
-            print(f"OK but DATE FILTER NEEDED")
+            return True
         else:
-            print(f"ERROR\n", self.dry_run_result["errors"])
+            print("ERROR\n", self.dry_run_result["errors"])
             return False
 
-        return True
+    def errors(self):
+        """Dry run the provided SQL file and return errors."""
+        if self.dry_run_result is None:
+            return []
+        return self.dry_run_result.get("errors", [])
 
     def get_error(self) -> Optional[Errors]:
         """Get specific errors for edge case handling."""

--- a/generator/explores/client_counts_explore.py
+++ b/generator/explores/client_counts_explore.py
@@ -16,9 +16,7 @@ class ClientCountsExplore(Explore):
 
     type: str = "client_counts_explore"
 
-    def _to_lookml(
-        self, v1_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         queries = []
         if time_partitioning_group := self.get_view_time_partitioning_group(

--- a/generator/explores/client_counts_explore.py
+++ b/generator/explores/client_counts_explore.py
@@ -17,7 +17,7 @@ class ClientCountsExplore(Explore):
     type: str = "client_counts_explore"
 
     def _to_lookml(
-        self, client: bigquery.Client, v1_name: Optional[str]
+        self, v1_name: Optional[str]
     ) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         queries = []

--- a/generator/explores/client_counts_explore.py
+++ b/generator/explores/client_counts_explore.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from google.cloud import bigquery
-
 from ..views import View
 from . import Explore
 

--- a/generator/explores/events_explore.py
+++ b/generator/explores/events_explore.py
@@ -34,9 +34,7 @@ class EventsExplore(Explore):
         """Get an instance of this explore from a dictionary definition."""
         return EventsExplore(name, defn["views"], views_path)
 
-    def _to_lookml(
-        self, v1_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         name = self.name
         if not name.endswith("_counts"):
             name = "event_counts"

--- a/generator/explores/events_explore.py
+++ b/generator/explores/events_explore.py
@@ -35,7 +35,7 @@ class EventsExplore(Explore):
         return EventsExplore(name, defn["views"], views_path)
 
     def _to_lookml(
-        self, client: bigquery.Client, v1_name: Optional[str]
+        self, v1_name: Optional[str]
     ) -> List[Dict[str, Any]]:
         name = self.name
         if not name.endswith("_counts"):

--- a/generator/explores/events_explore.py
+++ b/generator/explores/events_explore.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from google.cloud import bigquery
-
 from ..views import EventsView, View
 from .explore import Explore
 

--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -27,7 +27,7 @@ class Explore:
         return {self.name: {"type": self.type, "views": self.views}}
 
     def to_lookml(
-        self, client: bigquery.Client, v1_name: Optional[str]
+        self, v1_name: Optional[str]
     ) -> List[Dict[str, Any]]:
         """
         Generate LookML for this explore.
@@ -63,7 +63,7 @@ class Explore:
                 )
 
         # We only update the first returned explore
-        new_lookml = self._to_lookml(client, v1_name)
+        new_lookml = self._to_lookml(v1_name)
         base_lookml.update(new_lookml[0])
         new_lookml[0] = base_lookml
 
@@ -71,7 +71,6 @@ class Explore:
 
     def _to_lookml(
         self,
-        client: bigquery.Client,
         v1_name: Optional[str],
     ) -> List[Dict[str, Any]]:
         raise NotImplementedError("Only implemented in subclasses")

--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import lkml
-from google.cloud import bigquery
 
 from ..views.lookml_utils import escape_filter_expr, slug_to_title
 

--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -26,9 +26,7 @@ class Explore:
         """Explore instance represented as a dict."""
         return {self.name: {"type": self.type, "views": self.views}}
 
-    def to_lookml(
-        self, v1_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    def to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """
         Generate LookML for this explore.
 

--- a/generator/explores/funnel_analysis_explore.py
+++ b/generator/explores/funnel_analysis_explore.py
@@ -37,7 +37,7 @@ class FunnelAnalysisExplore(Explore):
         return FunnelAnalysisExplore(name, defn["views"], views_path)
 
     def _to_lookml(
-        self, client: bigquery.Client, v1_name: Optional[str]
+        self, v1_name: Optional[str]
     ) -> List[Dict[str, Any]]:
         view_lookml = self.get_view_lookml("funnel_analysis")
         views = view_lookml["views"]

--- a/generator/explores/funnel_analysis_explore.py
+++ b/generator/explores/funnel_analysis_explore.py
@@ -36,9 +36,7 @@ class FunnelAnalysisExplore(Explore):
         """Get an instance of this explore from a dictionary definition."""
         return FunnelAnalysisExplore(name, defn["views"], views_path)
 
-    def _to_lookml(
-        self, v1_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         view_lookml = self.get_view_lookml("funnel_analysis")
         views = view_lookml["views"]
         n_events = len([d for d in views if d["name"].startswith("step_")])

--- a/generator/explores/funnel_analysis_explore.py
+++ b/generator/explores/funnel_analysis_explore.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from google.cloud import bigquery
-
 from ..views import View
 from . import Explore
 

--- a/generator/explores/glean_ping_explore.py
+++ b/generator/explores/glean_ping_explore.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from google.cloud import bigquery
 from mozilla_schema_generator.glean_ping import GleanPing
 
 from ..views import GleanPingView, View

--- a/generator/explores/glean_ping_explore.py
+++ b/generator/explores/glean_ping_explore.py
@@ -18,7 +18,7 @@ class GleanPingExplore(PingExplore):
     type: str = "glean_ping_explore"
 
     def _to_lookml(
-        self, client: bigquery.Client, v1_name: Optional[str]
+        self, v1_name: Optional[str]
     ) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         repo = next((r for r in GleanPing.get_repos() if r["name"] == v1_name))

--- a/generator/explores/glean_ping_explore.py
+++ b/generator/explores/glean_ping_explore.py
@@ -17,9 +17,7 @@ class GleanPingExplore(PingExplore):
 
     type: str = "glean_ping_explore"
 
-    def _to_lookml(
-        self, v1_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         repo = next((r for r in GleanPing.get_repos() if r["name"] == v1_name))
         glean_app = GleanPing(repo)

--- a/generator/explores/growth_accounting_explore.py
+++ b/generator/explores/growth_accounting_explore.py
@@ -16,9 +16,7 @@ class GrowthAccountingExplore(Explore):
 
     type: str = "growth_accounting_explore"
 
-    def _to_lookml(
-        self, v1_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         return [
             {

--- a/generator/explores/growth_accounting_explore.py
+++ b/generator/explores/growth_accounting_explore.py
@@ -17,7 +17,7 @@ class GrowthAccountingExplore(Explore):
     type: str = "growth_accounting_explore"
 
     def _to_lookml(
-        self, client: bigquery.Client, v1_name: Optional[str]
+        self, v1_name: Optional[str]
     ) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         return [

--- a/generator/explores/growth_accounting_explore.py
+++ b/generator/explores/growth_accounting_explore.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from google.cloud import bigquery
-
 from ..views import View
 from . import Explore
 

--- a/generator/explores/metric_definitions_explore.py
+++ b/generator/explores/metric_definitions_explore.py
@@ -40,7 +40,6 @@ class MetricDefinitionsExplore(Explore):
 
     def _to_lookml(
         self,
-        _bq_client: bigquery.Client,
         _v1_name: Optional[str],
     ) -> List[Dict[str, Any]]:
         exposed_fields = ["ALL_FIELDS*"]

--- a/generator/explores/metric_definitions_explore.py
+++ b/generator/explores/metric_definitions_explore.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from google.cloud import bigquery
-
 from ..views import View
 from . import Explore
 

--- a/generator/explores/operational_monitoring_explore.py
+++ b/generator/explores/operational_monitoring_explore.py
@@ -50,7 +50,6 @@ class OperationalMonitoringExplore(Explore):
 
     def _to_lookml(
         self,
-        bq_client: bigquery.Client,
         v1_name: Optional[str],
     ) -> List[Dict[str, Any]]:
         base_view_name = self.views["base_view"]
@@ -115,7 +114,6 @@ class OperationalMonitoringAlertingExplore(Explore):
 
     def _to_lookml(
         self,
-        bq_client: bigquery.Client,
         v1_name: Optional[str],
     ) -> List[Dict[str, Any]]:
         defn: List[Dict[str, Any]] = [

--- a/generator/explores/operational_monitoring_explore.py
+++ b/generator/explores/operational_monitoring_explore.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from google.cloud import bigquery
-
 from ..views import View
 from . import Explore
 

--- a/generator/explores/ping_explore.py
+++ b/generator/explores/ping_explore.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from google.cloud import bigquery
-
 from ..views import PingView, View
 from . import Explore
 

--- a/generator/explores/ping_explore.py
+++ b/generator/explores/ping_explore.py
@@ -16,9 +16,7 @@ class PingExplore(Explore):
 
     type: str = "ping_explore"
 
-    def _to_lookml(
-        self, v1_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         return [
             {

--- a/generator/explores/ping_explore.py
+++ b/generator/explores/ping_explore.py
@@ -17,7 +17,7 @@ class PingExplore(Explore):
     type: str = "ping_explore"
 
     def _to_lookml(
-        self, client: bigquery.Client, v1_name: Optional[str]
+        self, v1_name: Optional[str]
     ) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         return [

--- a/generator/explores/table_explore.py
+++ b/generator/explores/table_explore.py
@@ -19,7 +19,7 @@ class TableExplore(Explore):
     type: str = "table_explore"
 
     def _to_lookml(
-        self, client: bigquery.Client, v1_name: Optional[str]
+        self, v1_name: Optional[str]
     ) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         explore_lookml: Dict[str, Any] = {

--- a/generator/explores/table_explore.py
+++ b/generator/explores/table_explore.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from google.cloud import bigquery
-
 from ..views import TableView, View
 from . import Explore
 

--- a/generator/explores/table_explore.py
+++ b/generator/explores/table_explore.py
@@ -18,9 +18,7 @@ class TableExplore(Explore):
 
     type: str = "table_explore"
 
-    def _to_lookml(
-        self, v1_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
         explore_lookml: Dict[str, Any] = {
             "name": self.name,

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -98,7 +98,9 @@ def _glean_apps_to_v1_map(glean_apps):
     return {d["name"]: d["v1_name"] for d in glean_apps}
 
 
-def _lookml(namespaces, glean_apps, target_dir, namespace_filter=[]):
+def _lookml(
+    namespaces, glean_apps, target_dir, namespace_filter=[], use_cloud_function=False
+):
     namespaces_content = namespaces.read()
     _namespaces = yaml.safe_load(namespaces_content)
     target = Path(target_dir)
@@ -178,10 +180,18 @@ def _lookml(namespaces, glean_apps, target_dir, namespace_filter=[]):
     default=[],
     help="List of namespace names to generate lookml for.",
 )
-def lookml(namespaces, app_listings_uri, target_dir, metric_hub_repos, only):
+@click.option(
+    "--use_cloud_function",
+    "--use-cloud-function",
+    default=False,
+    help="Use the Cloud Function to run dry runs during LookML generation.",
+)
+def lookml(
+    namespaces, app_listings_uri, target_dir, metric_hub_repos, only, use_cloud_function
+):
     """Generate lookml from namespaces."""
     if metric_hub_repos:
         MetricsConfigLoader.update_repos(metric_hub_repos)
 
     glean_apps = _get_glean_apps(app_listings_uri)
-    return _lookml(namespaces, glean_apps, target_dir, only)
+    return _lookml(namespaces, glean_apps, target_dir, only, use_cloud_function)

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -10,6 +10,8 @@ import lkml
 import yaml
 from google.cloud import bigquery
 
+from generator.utils import get_file_from_looker_hub
+
 from .dashboards import DASHBOARD_TYPES
 from .dryrun import DryRun, DryRunError, Errors, id_token
 from .explores import EXPLORE_TYPES
@@ -48,7 +50,10 @@ def _generate_views(
             yield path
         except DryRunError as e:
             if e.error == Errors.PERMISSION_DENIED and e.use_cloud_function:
-                print(f"Permission error dry running: {path}")
+                print(
+                    f"Permission error dry running: {path}. Copy existing file from looker-hub."
+                )
+                get_file_from_looker_hub(path)
             else:
                 raise e
 

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -55,9 +55,9 @@ def _generate_views(
                 )
                 try:
                     get_file_from_looker_hub(path)
+                    yield path
                 except Exception as ex:
                     print(f"Skip generating view for {path}: {ex}")
-                yield path
             else:
                 raise
 

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -381,15 +381,13 @@ def namespaces(
         custom_namespaces = yaml.safe_load(custom_namespaces.read()) or {}
         # remove namespaces that should be ignored
         for ignored_namespace in ignore:
-            del custom_namespaces[ignored_namespace]
+            if ignored_namespace in custom_namespaces:
+                del custom_namespaces[ignored_namespace]
 
         # generating operational monitoring namespace, if available
         if "operational_monitoring" in custom_namespaces:
             if use_cloud_function:
-                raise Exception(
-                    "Cannot generate OpMon using dry run Cloud Function"
-                    + "`export USE_CLOUD_FUNCTION=False` to use user GCP credentials"
-                )
+                raise Exception("Cannot generate OpMon using dry run Cloud Function")
 
             client = bigquery.Client()
             opmon = _get_opmon(bq_client=client, namespaces=custom_namespaces)

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -17,7 +17,6 @@ import yaml
 from google.cloud import bigquery
 
 from generator import operational_monitoring_utils
-from generator.dryrun import DryRun
 
 from .explores import EXPLORE_TYPES
 from .metrics_utils import LOOKER_METRIC_HUB_REPO, METRIC_HUB_REPO, MetricsConfigLoader
@@ -386,14 +385,13 @@ def namespaces(
 
         # generating operational monitoring namespace, if available
         if "operational_monitoring" in custom_namespaces:
-            dryrun = DryRun(use_cloud_function=use_cloud_function)
-            if dryrun.use_cloud_function:
+            if use_cloud_function:
                 raise Exception(
                     "Cannot generate OpMon using dry run Cloud Function"
                     + "`export USE_CLOUD_FUNCTION=False` to use user GCP credentials"
                 )
 
-            client = dryrun.client
+            client = bigquery.Client()
             opmon = _get_opmon(bq_client=client, namespaces=custom_namespaces)
             custom_namespaces["operational_monitoring"].update(opmon)
 

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -336,12 +336,19 @@ def _get_metric_hub_data_sources() -> Dict[str, List[str]]:
     default=[METRIC_HUB_REPO, LOOKER_METRIC_HUB_REPO],
     help="Repos to load metric configs from.",
 )
+@click.option(
+    "--ignore",
+    multiple=True,
+    default=[],
+    help="Namespaces to ignore during generation.",
+)
 def namespaces(
     custom_namespaces,
     generated_sql_uri,
     app_listings_uri,
     disallowlist,
     metric_hub_repos,
+    ignore,
 ):
     """Generate namespaces.yaml."""
     warnings.filterwarnings("ignore", module="google.auth._default")
@@ -350,20 +357,24 @@ def namespaces(
 
     namespaces = {}
     for app in glean_apps:
-        looker_views = _get_looker_views(app, db_views)
-        explores = _get_explores(looker_views)
-        views_as_dict = {view.name: view.as_dict() for view in looker_views}
+        if app["name"] not in ignore:
+            looker_views = _get_looker_views(app, db_views)
+            explores = _get_explores(looker_views)
+            views_as_dict = {view.name: view.as_dict() for view in looker_views}
 
-        namespaces[app["name"]] = {
-            "owners": app["owners"],
-            "pretty_name": app["pretty_name"],
-            "views": views_as_dict,
-            "explores": explores,
-            "glean_app": True,
-        }
+            namespaces[app["name"]] = {
+                "owners": app["owners"],
+                "pretty_name": app["pretty_name"],
+                "views": views_as_dict,
+                "explores": explores,
+                "glean_app": True,
+            }
 
     if custom_namespaces is not None:
         custom_namespaces = yaml.safe_load(custom_namespaces.read()) or {}
+        # remove namespaces that should be ignored
+        for ignored_namespace in ignore:
+            del custom_namespaces[ignored_namespace]
 
         # generating operational monitoring namespace, if available
         if "operational_monitoring" in custom_namespaces:
@@ -386,7 +397,10 @@ def namespaces(
 
     updated_namespaces = {}
     for namespace, _ in namespaces.items():
-        if not disallowed_namespaces_pattern.fullmatch(namespace):
+        if (
+            not disallowed_namespaces_pattern.fullmatch(namespace)
+            and namespace not in ignore
+        ):
             if "spoke" not in namespaces[namespace]:
                 namespaces[namespace]["spoke"] = DEFAULT_SPOKE
             if "glean_app" not in namespaces[namespace]:

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -17,6 +17,7 @@ import yaml
 from google.cloud import bigquery
 
 from generator import operational_monitoring_utils
+from generator.dryrun import DryRun
 
 from .explores import EXPLORE_TYPES
 from .metrics_utils import LOOKER_METRIC_HUB_REPO, METRIC_HUB_REPO, MetricsConfigLoader
@@ -378,7 +379,14 @@ def namespaces(
 
         # generating operational monitoring namespace, if available
         if "operational_monitoring" in custom_namespaces:
-            client = bigquery.Client()
+            dryrun = DryRun()
+            if dryrun.use_cloud_function:
+                raise Exception(
+                    "Cannot generate OpMon using dry run Cloud Function"
+                    + "`export USE_CLOUD_FUNCTION=False` to use user GCP credentials"
+                )
+
+            client = dryrun.client
             opmon = _get_opmon(bq_client=client, namespaces=custom_namespaces)
             custom_namespaces["operational_monitoring"].update(opmon)
 

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -343,6 +343,12 @@ def _get_metric_hub_data_sources() -> Dict[str, List[str]]:
     default=[],
     help="Namespaces to ignore during generation.",
 )
+@click.option(
+    "--use_cloud_function",
+    "--use-cloud-function",
+    help="Use the Cloud Function to run dry runs during LookML generation.",
+    type=bool,
+)
 def namespaces(
     custom_namespaces,
     generated_sql_uri,
@@ -350,6 +356,7 @@ def namespaces(
     disallowlist,
     metric_hub_repos,
     ignore,
+    use_cloud_function,
 ):
     """Generate namespaces.yaml."""
     warnings.filterwarnings("ignore", module="google.auth._default")
@@ -379,7 +386,7 @@ def namespaces(
 
         # generating operational monitoring namespace, if available
         if "operational_monitoring" in custom_namespaces:
-            dryrun = DryRun()
+            dryrun = DryRun(use_cloud_function=use_cloud_function)
             if dryrun.use_cloud_function:
                 raise Exception(
                     "Cannot generate OpMon using dry run Cloud Function"

--- a/generator/operational_monitoring_utils.py
+++ b/generator/operational_monitoring_utils.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from google.api_core import exceptions
 from google.cloud import bigquery
 
+from generator.dryrun import DryRun
+
 from .views import lookml_utils
 
 
@@ -53,15 +55,13 @@ def get_dimension_defaults(
         }
 
 
-def get_xaxis_val(table: str, use_cloud_function: bool) -> str:
+def get_xaxis_val(table: str, dryrun) -> str:
     """
     Return whether the x-axis should be build_id or submission_date.
 
     This is based on which one is found in the table provided.
     """
-    all_dimensions = lookml_utils._generate_dimensions(
-        table, use_cloud_function=use_cloud_function
-    )
+    all_dimensions = lookml_utils._generate_dimensions(table, dryrun=dryrun)
     return (
         "build_id"
         if "build_id" in {dimension["name"] for dimension in all_dimensions}

--- a/generator/operational_monitoring_utils.py
+++ b/generator/operational_monitoring_utils.py
@@ -6,8 +6,6 @@ from typing import Any, Dict, List, Optional, Tuple
 from google.api_core import exceptions
 from google.cloud import bigquery
 
-from generator.dryrun import DryRun
-
 from .views import lookml_utils
 
 

--- a/generator/operational_monitoring_utils.py
+++ b/generator/operational_monitoring_utils.py
@@ -53,13 +53,13 @@ def get_dimension_defaults(
         }
 
 
-def get_xaxis_val(bq_client: bigquery.Client, table: str) -> str:
+def get_xaxis_val(table: str) -> str:
     """
     Return whether the x-axis should be build_id or submission_date.
 
     This is based on which one is found in the table provided.
     """
-    all_dimensions = lookml_utils._generate_dimensions(bq_client, table)
+    all_dimensions = lookml_utils._generate_dimensions(table)
     return (
         "build_id"
         if "build_id" in {dimension["name"] for dimension in all_dimensions}

--- a/generator/operational_monitoring_utils.py
+++ b/generator/operational_monitoring_utils.py
@@ -53,13 +53,15 @@ def get_dimension_defaults(
         }
 
 
-def get_xaxis_val(table: str) -> str:
+def get_xaxis_val(table: str, use_cloud_function: bool) -> str:
     """
     Return whether the x-axis should be build_id or submission_date.
 
     This is based on which one is found in the table provided.
     """
-    all_dimensions = lookml_utils._generate_dimensions(table)
+    all_dimensions = lookml_utils._generate_dimensions(
+        table, use_cloud_function=use_cloud_function
+    )
     return (
         "build_id"
         if "build_id" in {dimension["name"] for dimension in all_dimensions}

--- a/generator/utils.py
+++ b/generator/utils.py
@@ -1,0 +1,20 @@
+"""Utils."""
+
+import urllib.request
+from pathlib import Path
+
+LOOKER_HUB_URL = "https://raw.githubusercontent.com/mozilla/looker-hub/main"
+
+
+def get_file_from_looker_hub(path: Path):
+    """Download a specific lookml artifact from looker-hub."""
+    file = path.name
+    artifact_type = path.parent.name
+    namespace = path.parent.parent.name
+    print(f"{LOOKER_HUB_URL}/{namespace}/{artifact_type}/{file}")
+    with urllib.request.urlopen(
+        f"{LOOKER_HUB_URL}/{namespace}/{artifact_type}/{file}"
+    ) as response:
+        lookml = response.read().decode(response.headers.get_content_charset())
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(lookml)

--- a/generator/views/client_counts_view.py
+++ b/generator/views/client_counts_view.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Dict, Iterator, List, Optional, Union
 
+from generator.dryrun import DryRun
+
 from .view import View, ViewDict
 
 
@@ -107,9 +109,7 @@ class ClientCountsView(View):
         """Get a view from a name and dict definition."""
         return ClientCountsView(namespace, _dict["tables"], name)
 
-    def to_lookml(
-        self, v1_name: Optional[str], use_cloud_function: bool
-    ) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str], dryrun) -> Dict[str, Any]:
         """Generate LookML for this view."""
         table = self.tables[0]["table"]
 

--- a/generator/views/client_counts_view.py
+++ b/generator/views/client_counts_view.py
@@ -107,7 +107,7 @@ class ClientCountsView(View):
         """Get a view from a name and dict definition."""
         return ClientCountsView(namespace, _dict["tables"], name)
 
-    def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
         """Generate LookML for this view."""
         table = self.tables[0]["table"]
 

--- a/generator/views/client_counts_view.py
+++ b/generator/views/client_counts_view.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Dict, Iterator, List, Optional, Union
 
-from generator.dryrun import DryRun
-
 from .view import View, ViewDict
 
 

--- a/generator/views/client_counts_view.py
+++ b/generator/views/client_counts_view.py
@@ -107,7 +107,9 @@ class ClientCountsView(View):
         """Get a view from a name and dict definition."""
         return ClientCountsView(namespace, _dict["tables"], name)
 
-    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(
+        self, v1_name: Optional[str], use_cloud_function: bool
+    ) -> Dict[str, Any]:
         """Generate LookML for this view."""
         table = self.tables[0]["table"]
 

--- a/generator/views/datagroups.py
+++ b/generator/views/datagroups.py
@@ -3,12 +3,11 @@
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import lkml
-from google.api_core.exceptions import NotFound
-from google.cloud import bigquery
 
+from generator.dryrun import DryRun
 from generator.namespaces import DEFAULT_GENERATED_SQL_URI
 from generator.views import TableView, View, lookml_utils
 from generator.views.lookml_utils import BQViewReferenceMap
@@ -51,16 +50,19 @@ class Datagroup:
         return self.name < other.name
 
 
-def _get_datagroup_from_bigquery_table(table: bigquery.Table) -> Datagroup:
+def _get_datagroup_from_bigquery_table(
+    project_id, dataset_id, table_id, table_metadata: Dict[str, Any]
+) -> Datagroup:
     """Use template and default values to create a Datagroup from a BQ Table."""
+    full_table_id = f"{project_id}.{dataset_id}.{table_id}"
     return Datagroup(
-        name=f"{table.table_id}_last_updated",
-        label=f"{table.friendly_name or table.table_id} Last Updated",
-        description=f"Updates when {table.full_table_id} is modified.",
+        name=f"{table_id}_last_updated",
+        label=f"{table_metadata.get('friendlyName', table_id)} Last Updated",
+        description=f"Updates when {full_table_id} is modified.",
         sql_trigger=SQL_TRIGGER_TEMPLATE.format(
-            project_id=table.project,
-            dataset_id=table.dataset_id,
-            table_id=table.table_id,
+            project_id=project_id,
+            dataset_id=dataset_id,
+            table_id=table_id,
         ),
         # Note: Ideally we'd use the table's ETL schedule as the `maximum_cache_age` but we don't have schedule
         # metadata here.
@@ -68,40 +70,58 @@ def _get_datagroup_from_bigquery_table(table: bigquery.Table) -> Datagroup:
 
 
 def _get_datagroup_from_bigquery_view(
-    view: bigquery.Table,
-    client: bigquery.Client,
+    project_id,
+    dataset_id,
+    table_id,
+    table_metadata: Dict[str, Any],
     dataset_view_map: BQViewReferenceMap,
 ) -> Optional[Datagroup]:
     # Dataset view map only contains references for shared-prod views.
-    if view.project not in ("moz-fx-data-shared-prod", "mozdata"):
+    full_table_id = f"{project_id}.{dataset_id}.{table_id}"
+    if project_id not in ("moz-fx-data-shared-prod", "mozdata"):
         logging.debug(
-            f"Unable to get sources for non shared-prod/mozdata view: {view.full_table_id} in generated-sql."
+            f"Unable to get sources for non shared-prod/mozdata view: {full_table_id} in generated-sql."
         )
         return None
 
-    dataset_view_references = dataset_view_map.get(view.dataset_id)
+    dataset_view_references = dataset_view_map.get(dataset_id)
     if dataset_view_references is None:
-        logging.debug(f"Unable to find dataset {view.dataset_id} in generated-sql.")
+        logging.debug(f"Unable to find dataset {dataset_id} in generated-sql.")
         return None
 
-    view_references = dataset_view_references.get(view.table_id)
+    view_references = dataset_view_references.get(table_id)
     if not view_references or len(view_references) > 1:
         # For views with multiple sources it's unclear which table to check for updates.
         logging.debug(
-            f"Unable to find a single source for {view.full_table_id} in generated-sql."
+            f"Unable to find a single source for {full_table_id} in generated-sql."
         )
         return None
 
     source_table_id = ".".join(view_references[0])
     try:
-        table = client.get_table(source_table_id)
-        if "TABLE" == table.table_type:
-            return _get_datagroup_from_bigquery_table(table)
-        elif "VIEW" == table.table_type:
-            return _get_datagroup_from_bigquery_view(table, client, dataset_view_map)
-    except NotFound as e:
+        table_metadata = DryRun(
+            project=view_references[0][0],
+            dataset=view_references[0][1],
+            table=view_references[0][2],
+        ).get_table_metadata()
+        if "TABLE" == table_metadata.get("tableType"):
+            return _get_datagroup_from_bigquery_table(
+                view_references[0][0],
+                view_references[0][1],
+                view_references[0][2],
+                table_metadata,
+            )
+        elif "VIEW" == table_metadata.get("tableType"):
+            return _get_datagroup_from_bigquery_view(
+                view_references[0][0],
+                view_references[0][1],
+                view_references[0][2],
+                table_metadata,
+                dataset_view_map,
+            )
+    except TypeError as e:
         raise ValueError(
-            f"Unable to find {source_table_id} referenced in {view.full_table_id}"
+            f"Unable to find {source_table_id} referenced in {full_table_id}"
         ) from e
 
     return None
@@ -109,7 +129,6 @@ def _get_datagroup_from_bigquery_view(
 
 def _generate_view_datagroup(
     view: View,
-    client: bigquery.Client,
     dataset_view_map: BQViewReferenceMap,
 ) -> Optional[Datagroup]:
     """Generate the Datagroup LookML for a Looker View."""
@@ -123,19 +142,19 @@ def _generate_view_datagroup(
         view.tables[0],
     )["table"]
 
-    try:
-        bq_table = client.get_table(view_table)
-    except NotFound as e:
-        raise ValueError(
-            f"{view_table} not found when generating datagroup but in namespaces yaml."
-        ) from e
+    [project, dataset, table] = view_table.split(".")
+    table_metadata = DryRun(
+        project=project, dataset=dataset, table=table
+    ).get_table_metadata()
 
-    if "TABLE" == bq_table.table_type:
-        datagroup: Optional[Datagroup] = _get_datagroup_from_bigquery_table(bq_table)
+    if "TABLE" == table_metadata.get("tableType"):
+        datagroup: Optional[Datagroup] = _get_datagroup_from_bigquery_table(
+            project, dataset, table, table_metadata
+        )
         return datagroup
-    elif "VIEW" == bq_table.table_type:
+    elif "VIEW" == table_metadata.get("tableType"):
         datagroup = _get_datagroup_from_bigquery_view(
-            bq_table, client, dataset_view_map
+            project, dataset, table, table_metadata, dataset_view_map
         )
         return datagroup
 
@@ -143,7 +162,9 @@ def _generate_view_datagroup(
 
 
 def generate_datagroups(
-    views: List[View], target_dir: Path, namespace: str, client: bigquery.Client
+    views: List[View],
+    target_dir: Path,
+    namespace: str,
 ) -> None:
     """Generate and write a datagroups.lkml file to the namespace folder."""
     datagroups_folder_path = target_dir / namespace / "datagroups"
@@ -157,7 +178,7 @@ def generate_datagroups(
         set(
             datagroup
             for view in views
-            if (datagroup := _generate_view_datagroup(view, client, dataset_view_map))
+            if (datagroup := _generate_view_datagroup(view, dataset_view_map))
             is not None
         )
     )

--- a/generator/views/datagroups.py
+++ b/generator/views/datagroups.py
@@ -122,7 +122,7 @@ def _get_datagroup_from_bigquery_view(
                 dataset_view_map,
                 dryrun=dryrun,
             )
-    except TypeError as e:
+    except DryRunError as e:
         raise ValueError(
             f"Unable to find {source_table_id} referenced in {full_table_id}"
         ) from e
@@ -206,7 +206,7 @@ def generate_datagroups(
                 except Exception as ex:
                     print(f"Skip generating datagroup for {path}: {ex}")
             else:
-                raise e
+                raise
 
     if datagroups:
         datagroups_folder_path.mkdir(exist_ok=True)

--- a/generator/views/events_view.py
+++ b/generator/views/events_view.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Dict, Iterator, List, Optional
 
-from generator.dryrun import DryRun
-
 from . import lookml_utils
 from .view import View, ViewDict
 

--- a/generator/views/events_view.py
+++ b/generator/views/events_view.py
@@ -61,7 +61,9 @@ class EventsView(View):
         """Get a view from a name and dict definition."""
         return EventsView(namespace, name, _dict["tables"])
 
-    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(
+        self, v1_name: Optional[str], use_cloud_function: bool
+    ) -> Dict[str, Any]:
         """Generate LookML for this view."""
         view_defn: Dict[str, Any] = {
             "extends": [self.tables[0]["events_table_view"]],
@@ -69,7 +71,9 @@ class EventsView(View):
         }
 
         # add measures
-        dimensions = lookml_utils._generate_dimensions(self.tables[0]["base_table"])
+        dimensions = lookml_utils._generate_dimensions(
+            self.tables[0]["base_table"], use_cloud_function=use_cloud_function
+        )
         view_defn["measures"] = self.get_measures(dimensions)
 
         # set document_id as primary key if it exists in the underlying table

--- a/generator/views/events_view.py
+++ b/generator/views/events_view.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Dict, Iterator, List, Optional
 
+from generator.dryrun import DryRun
+
 from . import lookml_utils
 from .view import View, ViewDict
 
@@ -61,9 +63,7 @@ class EventsView(View):
         """Get a view from a name and dict definition."""
         return EventsView(namespace, name, _dict["tables"])
 
-    def to_lookml(
-        self, v1_name: Optional[str], use_cloud_function: bool
-    ) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str], dryrun) -> Dict[str, Any]:
         """Generate LookML for this view."""
         view_defn: Dict[str, Any] = {
             "extends": [self.tables[0]["events_table_view"]],
@@ -72,7 +72,7 @@ class EventsView(View):
 
         # add measures
         dimensions = lookml_utils._generate_dimensions(
-            self.tables[0]["base_table"], use_cloud_function=use_cloud_function
+            self.tables[0]["base_table"], dryrun=dryrun
         )
         view_defn["measures"] = self.get_measures(dimensions)
 

--- a/generator/views/events_view.py
+++ b/generator/views/events_view.py
@@ -69,9 +69,7 @@ class EventsView(View):
         }
 
         # add measures
-        dimensions = lookml_utils._generate_dimensions(
-            self.tables[0]["base_table"]
-        )
+        dimensions = lookml_utils._generate_dimensions(self.tables[0]["base_table"])
         view_defn["measures"] = self.get_measures(dimensions)
 
         # set document_id as primary key if it exists in the underlying table

--- a/generator/views/events_view.py
+++ b/generator/views/events_view.py
@@ -61,7 +61,7 @@ class EventsView(View):
         """Get a view from a name and dict definition."""
         return EventsView(namespace, name, _dict["tables"])
 
-    def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
         """Generate LookML for this view."""
         view_defn: Dict[str, Any] = {
             "extends": [self.tables[0]["events_table_view"]],
@@ -70,7 +70,7 @@ class EventsView(View):
 
         # add measures
         dimensions = lookml_utils._generate_dimensions(
-            bq_client, self.tables[0]["base_table"]
+            self.tables[0]["base_table"]
         )
         view_defn["measures"] = self.get_measures(dimensions)
 

--- a/generator/views/funnel_analysis_view.py
+++ b/generator/views/funnel_analysis_view.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 from textwrap import dedent
 from typing import Any, Dict, Iterator, List, Optional
 
+from generator.dryrun import DryRun
+
 from .view import View, ViewDict
 
 DEFAULT_NUM_FUNNEL_STEPS: int = 4
@@ -89,9 +91,7 @@ class FunnelAnalysisView(View):
         """Get a FunnalAnalysisView from a dict representation."""
         return FunnelAnalysisView(namespace, _dict["tables"])
 
-    def to_lookml(
-        self, v1_name: Optional[str], use_cloud_function: bool
-    ) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str], dryrun) -> Dict[str, Any]:
         """Get this view as LookML."""
         return {
             "includes": [f"{self.tables[0]['funnel_analysis']}.view.lkml"],

--- a/generator/views/funnel_analysis_view.py
+++ b/generator/views/funnel_analysis_view.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 from textwrap import dedent
 from typing import Any, Dict, Iterator, List, Optional
 
-from generator.dryrun import DryRun
-
 from .view import View, ViewDict
 
 DEFAULT_NUM_FUNNEL_STEPS: int = 4

--- a/generator/views/funnel_analysis_view.py
+++ b/generator/views/funnel_analysis_view.py
@@ -89,7 +89,7 @@ class FunnelAnalysisView(View):
         """Get a FunnalAnalysisView from a dict representation."""
         return FunnelAnalysisView(namespace, _dict["tables"])
 
-    def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
         """Get this view as LookML."""
         return {
             "includes": [f"{self.tables[0]['funnel_analysis']}.view.lkml"],

--- a/generator/views/funnel_analysis_view.py
+++ b/generator/views/funnel_analysis_view.py
@@ -89,7 +89,9 @@ class FunnelAnalysisView(View):
         """Get a FunnalAnalysisView from a dict representation."""
         return FunnelAnalysisView(namespace, _dict["tables"])
 
-    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(
+        self, v1_name: Optional[str], use_cloud_function: bool
+    ) -> Dict[str, Any]:
         """Get this view as LookML."""
         return {
             "includes": [f"{self.tables[0]['funnel_analysis']}.view.lkml"],

--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -67,13 +67,13 @@ class GleanPingView(PingView):
             if view.name not in DISALLOWED_PINGS:
                 yield view
 
-    def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
         """Generate LookML for this view.
 
         The Glean views include a labeled metrics, which need to be joined
         against the view in the explore.
         """
-        lookml = super().to_lookml(bq_client, v1_name)
+        lookml = super().to_lookml(v1_name)
         # ignore nested join views
         lookml["views"] = [lookml["views"][0]]
 
@@ -84,7 +84,7 @@ class GleanPingView(PingView):
             (table for table in self.tables if table.get("channel") == "release"),
             self.tables[0],
         )["table"]
-        dimensions = self.get_dimensions(bq_client, table, v1_name)
+        dimensions = self.get_dimensions(table, v1_name)
         dimension_names = {dimension["name"] for dimension in dimensions}
 
         client_id_field = self.get_client_id(dimensions, table)

--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -10,8 +10,6 @@ import click
 from mozilla_schema_generator.glean_ping import GleanPing
 from mozilla_schema_generator.probes import GleanProbe
 
-from generator.dryrun import DryRun
-
 from . import lookml_utils
 from .lookml_utils import slug_to_title
 from .ping_view import PingView

--- a/generator/views/growth_accounting_view.py
+++ b/generator/views/growth_accounting_view.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 from itertools import filterfalse
 from typing import Any, Dict, Iterator, List, Optional, Union
 
+from generator.dryrun import DryRun
+
 from . import lookml_utils
 from .view import View, ViewDict
 
@@ -271,17 +273,13 @@ class GrowthAccountingView(View):
             ),
         )
 
-    def to_lookml(
-        self, v1_name: Optional[str], use_cloud_function: bool
-    ) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str], dryrun) -> Dict[str, Any]:
         """Generate LookML for this view."""
         view_defn: Dict[str, Any] = {"name": self.name}
         table = self.tables[0]["table"]
 
         # add dimensions and dimension groups
-        dimensions = lookml_utils._generate_dimensions(
-            table, use_cloud_function=use_cloud_function
-        ) + deepcopy(
+        dimensions = lookml_utils._generate_dimensions(table, dryrun=dryrun) + deepcopy(
             GrowthAccountingView.get_default_dimensions(
                 identifier_field=self.identifier_field
             )

--- a/generator/views/growth_accounting_view.py
+++ b/generator/views/growth_accounting_view.py
@@ -271,13 +271,13 @@ class GrowthAccountingView(View):
             ),
         )
 
-    def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
         """Generate LookML for this view."""
         view_defn: Dict[str, Any] = {"name": self.name}
         table = self.tables[0]["table"]
 
         # add dimensions and dimension groups
-        dimensions = lookml_utils._generate_dimensions(bq_client, table) + deepcopy(
+        dimensions = lookml_utils._generate_dimensions(table) + deepcopy(
             GrowthAccountingView.get_default_dimensions(
                 identifier_field=self.identifier_field
             )

--- a/generator/views/growth_accounting_view.py
+++ b/generator/views/growth_accounting_view.py
@@ -271,13 +271,17 @@ class GrowthAccountingView(View):
             ),
         )
 
-    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(
+        self, v1_name: Optional[str], use_cloud_function: bool
+    ) -> Dict[str, Any]:
         """Generate LookML for this view."""
         view_defn: Dict[str, Any] = {"name": self.name}
         table = self.tables[0]["table"]
 
         # add dimensions and dimension groups
-        dimensions = lookml_utils._generate_dimensions(table) + deepcopy(
+        dimensions = lookml_utils._generate_dimensions(
+            table, use_cloud_function=use_cloud_function
+        ) + deepcopy(
             GrowthAccountingView.get_default_dimensions(
                 identifier_field=self.identifier_field
             )

--- a/generator/views/growth_accounting_view.py
+++ b/generator/views/growth_accounting_view.py
@@ -6,8 +6,6 @@ from copy import deepcopy
 from itertools import filterfalse
 from typing import Any, Dict, Iterator, List, Optional, Union
 
-from generator.dryrun import DryRun
-
 from . import lookml_utils
 from .view import View, ViewDict
 

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -111,7 +111,7 @@ def _generate_dimensions_helper(schema: List[Any], *prefix: str) -> Iterable[dic
             )
 
 
-def _generate_dimensions(table: str, use_cloud_function: bool) -> List[Dict[str, Any]]:
+def _generate_dimensions(table: str, dryrun) -> List[Dict[str, Any]]:
     """Generate dimensions and dimension groups from a bigquery table.
 
     When schema contains both submission_timestamp and submission_date, only produce
@@ -121,11 +121,10 @@ def _generate_dimensions(table: str, use_cloud_function: bool) -> List[Dict[str,
     """
     dimensions = {}
     [project, dataset, table] = table.split(".")
-    table_schema = DryRun(
+    table_schema = dryrun(
         project=project,
         dataset=dataset,
         table=table,
-        use_cloud_function=use_cloud_function,
     ).get_table_schema()
 
     for dimension in _generate_dimensions_helper(table_schema):
@@ -149,11 +148,9 @@ def _generate_dimensions(table: str, use_cloud_function: bool) -> List[Dict[str,
     return list(dimensions.values())
 
 
-def _generate_dimensions_from_query(
-    query: str, use_cloud_function: bool
-) -> List[Dict[str, Any]]:
+def _generate_dimensions_from_query(query: str, dryrun) -> List[Dict[str, Any]]:
     """Generate dimensions and dimension groups from a SQL query."""
-    schema = DryRun(sql=query, use_cloud_function=use_cloud_function).get_schema()
+    schema = dryrun(sql=query).get_schema()
     dimensions = {}
     for dimension in _generate_dimensions_helper(schema or []):
         name_key = dimension["name"]

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -11,8 +11,6 @@ import click
 import yaml
 from jinja2 import Environment, PackageLoader
 
-from generator.dryrun import DryRun
-
 BIGQUERY_TYPE_TO_DIMENSION_TYPE = {
     "BIGNUMERIC": "string",
     "BOOLEAN": "yesno",

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -236,19 +236,6 @@ def render_template(filename, template_folder, **kwargs) -> str:
     return rendered
 
 
-def get_distinct_vals(bq_client: bigquery.Client, table: str, column: str):
-    """Given a table and column name, return all distinct values for that column."""
-    query_job = bq_client.query(
-        f"""
-            SELECT DISTINCT {column}
-            FROM {table}
-            ORDER BY {column}
-        """
-    )
-    distinct_values = query_job.result().to_dataframe()[column].tolist()
-    return distinct_values
-
-
 def slug_to_title(slug):
     """Convert a slug to title case."""
     return slug.replace("_", " ").title()

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -126,18 +126,21 @@ def _generate_dimensions(table: str, dryrun) -> List[Dict[str, Any]]:
     ).get_table_schema()
 
     for dimension in _generate_dimensions_helper(table_schema):
-        name = dimension["name"]
+        name_key = dimension["name"]
+
+        # This prevents `time` dimension groups from overwriting other dimensions below
+        if dimension.get("type") == "time":
+            name_key += "_time"
         # overwrite duplicate "submission", "end", "start" dimension group, thus picking the
         # last value sorted by field name, which is submission_timestamp
         # See also https://github.com/mozilla/lookml-generator/issues/471
-        if (
-            name in dimensions
-            and name != "submission"
-            and not name.endswith("end")
-            and not name.endswith("start")
-            and not (name == "event" and dimension["type"] == "time")
-            # workaround for `mozdata.firefox_desktop.desktop_installs`
-            and not (name == "attribution_dltoken" and dimension["type"] == "time")
+        if name_key in dimensions and not (
+            dimension.get("type") == "time"
+            and (
+                dimension["name"] == "submission"
+                or dimension["name"].endswith("end")
+                or dimension["name"].endswith("start")
+            )
         ):
             raise click.ClickException(
                 f"duplicate dimension {name_key!r} for table {table!r}"
@@ -174,7 +177,7 @@ def _generate_dimensions_from_query(query: str, dryrun) -> List[Dict[str, Any]]:
 
 
 def _generate_nested_dimension_views(
-    schema: dict, view_name: str
+    schema: List[dict], view_name: str
 ) -> List[Dict[str, Any]]:
     """
     Recursively generate views for nested fields.

--- a/generator/views/metric_definitions_view.py
+++ b/generator/views/metric_definitions_view.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, Iterator, List, Optional, Union
 
-from generator.dryrun import DryRun
 from generator.metrics_utils import MetricsConfigLoader
 
 from . import lookml_utils

--- a/generator/views/metric_definitions_view.py
+++ b/generator/views/metric_definitions_view.py
@@ -38,7 +38,7 @@ class MetricDefinitionsView(View):
         """Get a MetricDefinitionsView from a dict representation."""
         return klass(namespace, name, definition.get("tables", []))
 
-    def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
         """Get this view as LookML."""
         namespace_definitions = MetricsConfigLoader.configs.get_platform_definitions(
             self.namespace
@@ -122,7 +122,7 @@ class MetricDefinitionsView(View):
                     ).format(dataset=self.namespace)
 
                     base_view_dimensions[joined_data_source_slug] = (
-                        lookml_utils._generate_dimensions_from_query(bq_client, query)
+                        lookml_utils._generate_dimensions_from_query(query)
                     )
 
         if (
@@ -147,7 +147,7 @@ class MetricDefinitionsView(View):
             ).format(dataset=self.namespace)
 
             base_view_dimensions[data_source_definition.name] = (
-                lookml_utils._generate_dimensions_from_query(bq_client, query)
+                lookml_utils._generate_dimensions_from_query(query)
             )
 
         # prepare base field data for query

--- a/generator/views/metric_definitions_view.py
+++ b/generator/views/metric_definitions_view.py
@@ -38,7 +38,9 @@ class MetricDefinitionsView(View):
         """Get a MetricDefinitionsView from a dict representation."""
         return klass(namespace, name, definition.get("tables", []))
 
-    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(
+        self, v1_name: Optional[str], use_cloud_function: bool
+    ) -> Dict[str, Any]:
         """Get this view as LookML."""
         namespace_definitions = MetricsConfigLoader.configs.get_platform_definitions(
             self.namespace
@@ -122,7 +124,9 @@ class MetricDefinitionsView(View):
                     ).format(dataset=self.namespace)
 
                     base_view_dimensions[joined_data_source_slug] = (
-                        lookml_utils._generate_dimensions_from_query(query)
+                        lookml_utils._generate_dimensions_from_query(
+                            query, use_cloud_function=use_cloud_function
+                        )
                     )
 
         if (
@@ -147,7 +151,9 @@ class MetricDefinitionsView(View):
             ).format(dataset=self.namespace)
 
             base_view_dimensions[data_source_definition.name] = (
-                lookml_utils._generate_dimensions_from_query(query)
+                lookml_utils._generate_dimensions_from_query(
+                    query, use_cloud_function=use_cloud_function
+                )
             )
 
         # prepare base field data for query
@@ -253,7 +259,9 @@ class MetricDefinitionsView(View):
             """
         }
 
-        view_defn["dimensions"] = self.get_dimensions()
+        view_defn["dimensions"] = self.get_dimensions(
+            use_cloud_function=use_cloud_function
+        )
         view_defn["dimension_groups"] = self.get_dimension_groups()
 
         # add the Looker dimensions
@@ -283,7 +291,10 @@ class MetricDefinitionsView(View):
         return {"views": [view_defn]}
 
     def get_dimensions(
-        self, _bq_client=None, _table=None, _v1_name: Optional[str] = None
+        self,
+        _table=None,
+        _v1_name: Optional[str] = None,
+        use_cloud_function: bool = False,
     ) -> List[Dict[str, Any]]:
         """Get the set of dimensions for this view based on the metric definitions in metric-hub."""
         namespace_definitions = MetricsConfigLoader.configs.get_platform_definitions(

--- a/generator/views/metric_definitions_view.py
+++ b/generator/views/metric_definitions_view.py
@@ -255,7 +255,7 @@ class MetricDefinitionsView(View):
             """
         }
 
-        view_defn["dimensions"] = self.get_dimensions(dryrun=dryrun)
+        view_defn["dimensions"] = self.get_dimensions()
         view_defn["dimension_groups"] = self.get_dimension_groups()
 
         # add the Looker dimensions
@@ -288,7 +288,7 @@ class MetricDefinitionsView(View):
         self,
         _table=None,
         _v1_name: Optional[str] = None,
-        dryrun=False,
+        _dryrun=None,
     ) -> List[Dict[str, Any]]:
         """Get the set of dimensions for this view based on the metric definitions in metric-hub."""
         namespace_definitions = MetricsConfigLoader.configs.get_platform_definitions(

--- a/generator/views/metric_definitions_view.py
+++ b/generator/views/metric_definitions_view.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, Iterator, List, Optional, Union
 
+from generator.dryrun import DryRun
 from generator.metrics_utils import MetricsConfigLoader
 
 from . import lookml_utils
@@ -38,9 +39,7 @@ class MetricDefinitionsView(View):
         """Get a MetricDefinitionsView from a dict representation."""
         return klass(namespace, name, definition.get("tables", []))
 
-    def to_lookml(
-        self, v1_name: Optional[str], use_cloud_function: bool
-    ) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str], dryrun) -> Dict[str, Any]:
         """Get this view as LookML."""
         namespace_definitions = MetricsConfigLoader.configs.get_platform_definitions(
             self.namespace
@@ -125,7 +124,7 @@ class MetricDefinitionsView(View):
 
                     base_view_dimensions[joined_data_source_slug] = (
                         lookml_utils._generate_dimensions_from_query(
-                            query, use_cloud_function=use_cloud_function
+                            query, dryrun=dryrun
                         )
                     )
 
@@ -151,9 +150,7 @@ class MetricDefinitionsView(View):
             ).format(dataset=self.namespace)
 
             base_view_dimensions[data_source_definition.name] = (
-                lookml_utils._generate_dimensions_from_query(
-                    query, use_cloud_function=use_cloud_function
-                )
+                lookml_utils._generate_dimensions_from_query(query, dryrun=dryrun)
             )
 
         # prepare base field data for query
@@ -259,9 +256,7 @@ class MetricDefinitionsView(View):
             """
         }
 
-        view_defn["dimensions"] = self.get_dimensions(
-            use_cloud_function=use_cloud_function
-        )
+        view_defn["dimensions"] = self.get_dimensions(dryrun=dryrun)
         view_defn["dimension_groups"] = self.get_dimension_groups()
 
         # add the Looker dimensions
@@ -294,7 +289,7 @@ class MetricDefinitionsView(View):
         self,
         _table=None,
         _v1_name: Optional[str] = None,
-        use_cloud_function: bool = False,
+        dryrun=False,
     ) -> List[Dict[str, Any]]:
         """Get the set of dimensions for this view based on the metric definitions in metric-hub."""
         namespace_definitions = MetricsConfigLoader.configs.get_platform_definitions(

--- a/generator/views/operational_monitoring_alerting_view.py
+++ b/generator/views/operational_monitoring_alerting_view.py
@@ -11,7 +11,9 @@ class OperationalMonitoringAlertingView(OperationalMonitoringView):
 
     type: str = "operational_monitoring_alerting_view"
 
-    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(
+        self, v1_name: Optional[str], use_cloud_function: bool
+    ) -> Dict[str, Any]:
         """Get this view as LookML."""
         if len(self.tables) == 0:
             raise Exception((f"Operational Monitoring view {self.name} has no tables"))
@@ -19,7 +21,9 @@ class OperationalMonitoringAlertingView(OperationalMonitoringView):
         reference_table = self.tables[0]["table"]
         dimensions = [
             d
-            for d in lookml_utils._generate_dimensions(reference_table)
+            for d in lookml_utils._generate_dimensions(
+                reference_table, use_cloud_function=use_cloud_function
+            )
             if d["name"] != "submission"
         ]
 

--- a/generator/views/operational_monitoring_alerting_view.py
+++ b/generator/views/operational_monitoring_alerting_view.py
@@ -2,8 +2,6 @@
 
 from typing import Any, Dict, Optional
 
-from generator.dryrun import DryRun
-
 from . import lookml_utils
 from .operational_monitoring_view import OperationalMonitoringView
 

--- a/generator/views/operational_monitoring_alerting_view.py
+++ b/generator/views/operational_monitoring_alerting_view.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict, Optional
 
+from generator.dryrun import DryRun
+
 from . import lookml_utils
 from .operational_monitoring_view import OperationalMonitoringView
 
@@ -11,9 +13,7 @@ class OperationalMonitoringAlertingView(OperationalMonitoringView):
 
     type: str = "operational_monitoring_alerting_view"
 
-    def to_lookml(
-        self, v1_name: Optional[str], use_cloud_function: bool
-    ) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str], dryrun) -> Dict[str, Any]:
         """Get this view as LookML."""
         if len(self.tables) == 0:
             raise Exception((f"Operational Monitoring view {self.name} has no tables"))
@@ -21,9 +21,7 @@ class OperationalMonitoringAlertingView(OperationalMonitoringView):
         reference_table = self.tables[0]["table"]
         dimensions = [
             d
-            for d in lookml_utils._generate_dimensions(
-                reference_table, use_cloud_function=use_cloud_function
-            )
+            for d in lookml_utils._generate_dimensions(reference_table, dryrun=dryrun)
             if d["name"] != "submission"
         ]
 

--- a/generator/views/operational_monitoring_alerting_view.py
+++ b/generator/views/operational_monitoring_alerting_view.py
@@ -11,7 +11,7 @@ class OperationalMonitoringAlertingView(OperationalMonitoringView):
 
     type: str = "operational_monitoring_alerting_view"
 
-    def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
         """Get this view as LookML."""
         if len(self.tables) == 0:
             raise Exception((f"Operational Monitoring view {self.name} has no tables"))
@@ -19,7 +19,7 @@ class OperationalMonitoringAlertingView(OperationalMonitoringView):
         reference_table = self.tables[0]["table"]
         dimensions = [
             d
-            for d in lookml_utils._generate_dimensions(bq_client, reference_table)
+            for d in lookml_utils._generate_dimensions(reference_table)
             if d["name"] != "submission"
         ]
 

--- a/generator/views/operational_monitoring_view.py
+++ b/generator/views/operational_monitoring_view.py
@@ -49,13 +49,17 @@ class OperationalMonitoringView(PingView):
         """Get a OperationalMonitoringView from a dict representation."""
         return klass(namespace, name, _dict["tables"])
 
-    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(
+        self, v1_name: Optional[str], use_cloud_function: bool
+    ) -> Dict[str, Any]:
         """Get this view as LookML."""
         if len(self.tables) == 0:
             raise Exception((f"Operational Monitoring view {self.name} has no tables"))
 
         reference_table = self.tables[0]["table"]
-        all_dimensions = lookml_utils._generate_dimensions(reference_table)
+        all_dimensions = lookml_utils._generate_dimensions(
+            reference_table, use_cloud_function=use_cloud_function
+        )
 
         filtered_dimensions = [
             d

--- a/generator/views/operational_monitoring_view.py
+++ b/generator/views/operational_monitoring_view.py
@@ -49,13 +49,13 @@ class OperationalMonitoringView(PingView):
         """Get a OperationalMonitoringView from a dict representation."""
         return klass(namespace, name, _dict["tables"])
 
-    def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
         """Get this view as LookML."""
         if len(self.tables) == 0:
             raise Exception((f"Operational Monitoring view {self.name} has no tables"))
 
         reference_table = self.tables[0]["table"]
-        all_dimensions = lookml_utils._generate_dimensions(bq_client, reference_table)
+        all_dimensions = lookml_utils._generate_dimensions(reference_table)
 
         filtered_dimensions = [
             d

--- a/generator/views/operational_monitoring_view.py
+++ b/generator/views/operational_monitoring_view.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union
 
+from generator.dryrun import DryRun
+
 from . import lookml_utils
 from .ping_view import PingView
 from .view import ViewDict
@@ -49,16 +51,14 @@ class OperationalMonitoringView(PingView):
         """Get a OperationalMonitoringView from a dict representation."""
         return klass(namespace, name, _dict["tables"])
 
-    def to_lookml(
-        self, v1_name: Optional[str], use_cloud_function: bool
-    ) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str], dryrun) -> Dict[str, Any]:
         """Get this view as LookML."""
         if len(self.tables) == 0:
             raise Exception((f"Operational Monitoring view {self.name} has no tables"))
 
         reference_table = self.tables[0]["table"]
         all_dimensions = lookml_utils._generate_dimensions(
-            reference_table, use_cloud_function=use_cloud_function
+            reference_table, dryrun=dryrun
         )
 
         filtered_dimensions = [

--- a/generator/views/operational_monitoring_view.py
+++ b/generator/views/operational_monitoring_view.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union
 
-from generator.dryrun import DryRun
-
 from . import lookml_utils
 from .ping_view import PingView
 from .view import ViewDict

--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -66,9 +66,7 @@ class PingView(View):
         """Get a view from a name and dict definition."""
         return klass(namespace, name, _dict["tables"])
 
-    def to_lookml(
-        self, v1_name: Optional[str], use_cloud_function: bool
-    ) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str], dryrun) -> Dict[str, Any]:
         """Generate LookML for this view."""
         view_defn: Dict[str, Any] = {"name": self.name}
 
@@ -78,9 +76,7 @@ class PingView(View):
             self.tables[0],
         )["table"]
 
-        dimensions = self.get_dimensions(
-            table, v1_name, use_cloud_function=use_cloud_function
-        )
+        dimensions = self.get_dimensions(table, v1_name, dryrun=dryrun)
 
         # set document id field as a primary key for joins
         view_defn["dimensions"] = [
@@ -96,11 +92,10 @@ class PingView(View):
         view_defn["measures"] = self.get_measures(dimensions, table, v1_name)
 
         [project, dataset, table_id] = table.split(".")
-        table_schema = DryRun(
+        table_schema = dryrun(
             project=project,
             dataset=dataset,
             table=table_id,
-            use_cloud_function=use_cloud_function,
         ).get_table_schema()
         nested_views = lookml_utils._generate_nested_dimension_views(
             table_schema, self.name
@@ -130,13 +125,11 @@ class PingView(View):
         return {"views": [view_defn] + nested_views}
 
     def get_dimensions(
-        self, table, v1_name: Optional[str], use_cloud_function: bool
+        self, table, v1_name: Optional[str], dryrun
     ) -> List[Dict[str, Any]]:
         """Get the set of dimensions for this view."""
         # add dimensions and dimension groups
-        return lookml_utils._generate_dimensions(
-            table, use_cloud_function=use_cloud_function
-        )
+        return lookml_utils._generate_dimensions(table, dryrun=dryrun)
 
     def get_measures(
         self, dimensions: List[dict], table: str, v1_name: Optional[str]

--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any, Dict, Iterator, List, Optional, Union
 
+from generator.dryrun import DryRun
+
 from . import lookml_utils
 from .view import OMIT_VIEWS, View, ViewDict
-from dryrun import DryRun
 
 
 class PingView(View):
@@ -90,9 +91,9 @@ class PingView(View):
         # add measures
         view_defn["measures"] = self.get_measures(dimensions, table, v1_name)
 
-        [project, dataset, table] = table.split(".")
+        [project, dataset, table_id] = table.split(".")
         table_schema = DryRun(
-            project=project, dataset=dataset, table=table
+            project=project, dataset=dataset, table=table_id
         ).get_table_schema()
         nested_views = lookml_utils._generate_nested_dimension_views(
             table_schema, self.name
@@ -121,12 +122,10 @@ class PingView(View):
 
         return {"views": [view_defn] + nested_views}
 
-    def get_dimensions(
-        self, bq_client, table, v1_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    def get_dimensions(self, table, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Get the set of dimensions for this view."""
         # add dimensions and dimension groups
-        return lookml_utils._generate_dimensions(bq_client, table)
+        return lookml_utils._generate_dimensions(table)
 
     def get_measures(
         self, dimensions: List[dict], table: str, v1_name: Optional[str]

--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any, Dict, Iterator, List, Optional, Union
 
-from generator.dryrun import DryRun
-
 from . import lookml_utils
 from .view import OMIT_VIEWS, View, ViewDict
 

--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 
 from . import lookml_utils
 from .view import OMIT_VIEWS, View, ViewDict
+from dryrun import DryRun
 
 
 class PingView(View):
@@ -89,8 +90,12 @@ class PingView(View):
         # add measures
         view_defn["measures"] = self.get_measures(dimensions, table, v1_name)
 
+        [project, dataset, table] = table.split(".")
+        table_schema = DryRun(
+            project=project, dataset=dataset, table=table
+        ).get_table_schema()
         nested_views = lookml_utils._generate_nested_dimension_views(
-            bq_client.get_table(table).schema, self.name # todo
+            table_schema, self.name
         )
 
         # Round-tripping through a dict to get an ordered deduped list.

--- a/generator/views/ping_view.py
+++ b/generator/views/ping_view.py
@@ -64,7 +64,7 @@ class PingView(View):
         """Get a view from a name and dict definition."""
         return klass(namespace, name, _dict["tables"])
 
-    def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
         """Generate LookML for this view."""
         view_defn: Dict[str, Any] = {"name": self.name}
 
@@ -74,7 +74,7 @@ class PingView(View):
             self.tables[0],
         )["table"]
 
-        dimensions = self.get_dimensions(bq_client, table, v1_name)
+        dimensions = self.get_dimensions(table, v1_name)
 
         # set document id field as a primary key for joins
         view_defn["dimensions"] = [
@@ -90,7 +90,7 @@ class PingView(View):
         view_defn["measures"] = self.get_measures(dimensions, table, v1_name)
 
         nested_views = lookml_utils._generate_nested_dimension_views(
-            bq_client.get_table(table).schema, self.name
+            bq_client.get_table(table).schema, self.name # todo
         )
 
         # Round-tripping through a dict to get an ordered deduped list.

--- a/generator/views/table_view.py
+++ b/generator/views/table_view.py
@@ -103,11 +103,11 @@ class TableView(View):
                     f"time_partitioning_field {field_name!r} not found in {self.name!r}"
                 )
 
-        [project, dataset, table] = table.split(".")
+        [project, dataset, table_id] = table.split(".")
         table_schema = dryrun(
             project=project,
             dataset=dataset,
-            table=table,
+            table=table_id,
         ).get_table_schema()
         nested_views = lookml_utils._generate_nested_dimension_views(
             table_schema, self.name

--- a/generator/views/table_view.py
+++ b/generator/views/table_view.py
@@ -61,7 +61,7 @@ class TableView(View):
         """Get a view from a name and dict definition."""
         return TableView(namespace, name, _dict["tables"], _dict.get("measures"))
 
-    def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
         """Generate LookML for this view."""
         view_defn: Dict[str, Any] = {"name": self.name}
 
@@ -72,7 +72,7 @@ class TableView(View):
         )["table"]
 
         # add dimensions and dimension groups
-        dimensions = lookml_utils._generate_dimensions(bq_client, table)
+        dimensions = lookml_utils._generate_dimensions(table)
         view_defn["dimensions"] = list(
             filterfalse(lookml_utils._is_dimension_group, dimensions)
         )
@@ -104,7 +104,7 @@ class TableView(View):
                 )
 
         nested_views = lookml_utils._generate_nested_dimension_views(
-            bq_client.get_table(table).schema, self.name
+            bq_client.get_table(table).schema, self.name  # todo
         )
 
         if self.measures:

--- a/generator/views/table_view.py
+++ b/generator/views/table_view.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from itertools import filterfalse
 from typing import Any, Dict, Iterator, List, Optional, Set
+from dryrun import DryRun
 
 from click import ClickException
 
@@ -103,8 +104,12 @@ class TableView(View):
                     f"time_partitioning_field {field_name!r} not found in {self.name!r}"
                 )
 
+        [project, dataset, table] = table.split(".")
+        table_schema = DryRun(
+            project=project, dataset=dataset, table=table
+        ).get_table_schema()
         nested_views = lookml_utils._generate_nested_dimension_views(
-            bq_client.get_table(table).schema, self.name  # todo
+            table_schema, self.name
         )
 
         if self.measures:

--- a/generator/views/table_view.py
+++ b/generator/views/table_view.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections import defaultdict
 from itertools import filterfalse
 from typing import Any, Dict, Iterator, List, Optional, Set
-from dryrun import DryRun
 
 from click import ClickException
+
+from generator.dryrun import DryRun
 
 from . import lookml_utils
 from .view import OMIT_VIEWS, View, ViewDict

--- a/generator/views/table_view.py
+++ b/generator/views/table_view.py
@@ -63,7 +63,9 @@ class TableView(View):
         """Get a view from a name and dict definition."""
         return TableView(namespace, name, _dict["tables"], _dict.get("measures"))
 
-    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(
+        self, v1_name: Optional[str], use_cloud_function: bool
+    ) -> Dict[str, Any]:
         """Generate LookML for this view."""
         view_defn: Dict[str, Any] = {"name": self.name}
 
@@ -74,7 +76,9 @@ class TableView(View):
         )["table"]
 
         # add dimensions and dimension groups
-        dimensions = lookml_utils._generate_dimensions(table)
+        dimensions = lookml_utils._generate_dimensions(
+            table, use_cloud_function=use_cloud_function
+        )
         view_defn["dimensions"] = list(
             filterfalse(lookml_utils._is_dimension_group, dimensions)
         )
@@ -107,7 +111,10 @@ class TableView(View):
 
         [project, dataset, table] = table.split(".")
         table_schema = DryRun(
-            project=project, dataset=dataset, table=table
+            project=project,
+            dataset=dataset,
+            table=table,
+            use_cloud_function=use_cloud_function,
         ).get_table_schema()
         nested_views = lookml_utils._generate_nested_dimension_views(
             table_schema, self.name

--- a/generator/views/table_view.py
+++ b/generator/views/table_view.py
@@ -63,9 +63,7 @@ class TableView(View):
         """Get a view from a name and dict definition."""
         return TableView(namespace, name, _dict["tables"], _dict.get("measures"))
 
-    def to_lookml(
-        self, v1_name: Optional[str], use_cloud_function: bool
-    ) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str], dryrun) -> Dict[str, Any]:
         """Generate LookML for this view."""
         view_defn: Dict[str, Any] = {"name": self.name}
 
@@ -76,9 +74,7 @@ class TableView(View):
         )["table"]
 
         # add dimensions and dimension groups
-        dimensions = lookml_utils._generate_dimensions(
-            table, use_cloud_function=use_cloud_function
-        )
+        dimensions = lookml_utils._generate_dimensions(table, dryrun=dryrun)
         view_defn["dimensions"] = list(
             filterfalse(lookml_utils._is_dimension_group, dimensions)
         )
@@ -110,11 +106,10 @@ class TableView(View):
                 )
 
         [project, dataset, table] = table.split(".")
-        table_schema = DryRun(
+        table_schema = dryrun(
             project=project,
             dataset=dataset,
             table=table,
-            use_cloud_function=use_cloud_function,
         ).get_table_schema()
         nested_views = lookml_utils._generate_nested_dimension_views(
             table_schema, self.name

--- a/generator/views/table_view.py
+++ b/generator/views/table_view.py
@@ -8,8 +8,6 @@ from typing import Any, Dict, Iterator, List, Optional, Set
 
 from click import ClickException
 
-from generator.dryrun import DryRun
-
 from . import lookml_utils
 from .view import OMIT_VIEWS, View, ViewDict
 

--- a/generator/views/view.py
+++ b/generator/views/view.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, Iterator, List, Optional, Set, TypedDict
 
 from click import ClickException
 
+from generator.dryrun import DryRun
+
 OMIT_VIEWS: Set[str] = set()
 
 
@@ -87,14 +89,12 @@ class View(object):
         return False
 
     def get_dimensions(
-        self, table, v1_name: Optional[str], use_cloud_function: bool
+        self, table, v1_name: Optional[str], dryrun
     ) -> List[Dict[str, Any]]:
         """Get the set of dimensions for this view."""
         raise NotImplementedError("Only implemented in subclass.")
 
-    def to_lookml(
-        self, v1_name: Optional[str], use_cloud_function: bool
-    ) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str], dryrun) -> Dict[str, Any]:
         """
         Generate Lookml for this view.
 

--- a/generator/views/view.py
+++ b/generator/views/view.py
@@ -6,8 +6,6 @@ from typing import Any, Dict, Iterator, List, Optional, Set, TypedDict
 
 from click import ClickException
 
-from generator.dryrun import DryRun
-
 OMIT_VIEWS: Set[str] = set()
 
 

--- a/generator/views/view.py
+++ b/generator/views/view.py
@@ -86,9 +86,7 @@ class View(object):
             )
         return False
 
-    def get_dimensions(
-        self, table, v1_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    def get_dimensions(self, table, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Get the set of dimensions for this view."""
         raise NotImplementedError("Only implemented in subclass.")
 

--- a/generator/views/view.py
+++ b/generator/views/view.py
@@ -86,11 +86,15 @@ class View(object):
             )
         return False
 
-    def get_dimensions(self, table, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+    def get_dimensions(
+        self, table, v1_name: Optional[str], use_cloud_function: bool
+    ) -> List[Dict[str, Any]]:
         """Get the set of dimensions for this view."""
         raise NotImplementedError("Only implemented in subclass.")
 
-    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(
+        self, v1_name: Optional[str], use_cloud_function: bool
+    ) -> Dict[str, Any]:
         """
         Generate Lookml for this view.
 

--- a/generator/views/view.py
+++ b/generator/views/view.py
@@ -87,12 +87,12 @@ class View(object):
         return False
 
     def get_dimensions(
-        self, bq_client, table, v1_name: Optional[str]
+        self, table, v1_name: Optional[str]
     ) -> List[Dict[str, Any]]:
         """Get the set of dimensions for this view."""
         raise NotImplementedError("Only implemented in subclass.")
 
-    def to_lookml(self, bq_client, v1_name: Optional[str]) -> Dict[str, Any]:
+    def to_lookml(self, v1_name: Optional[str]) -> Dict[str, Any]:
         """
         Generate Lookml for this view.
 

--- a/tests/test_datagroups.py
+++ b/tests/test_datagroups.py
@@ -27,16 +27,13 @@ class MockDryRun:
     """Mock dryrun.DryRun."""
 
     def __init__(
-        self,
-        sql=None,
-        project=None,
-        dataset=None,
-        table=None,
+        self, sql=None, project=None, dataset=None, table=None, use_cloud_function=False
     ):
         self.sql = sql
         self.project = project
         self.dataset = dataset
         self.table = table
+        self.use_cloud_function = use_cloud_function
 
     def get_table_metadata(self):
         """Mock dryrun.DryRun.get_table_metadata"""
@@ -117,6 +114,7 @@ def test_generates_datagroups(reference_map_mock, runner):
             views,
             target_dir=Path("looker-hub"),
             namespace="test_namespace",
+            use_cloud_function=False,
         )
 
         assert Path(namespace_dir / "datagroups").exists()
@@ -201,6 +199,7 @@ def test_generates_datagroups_with_tables_and_views(reference_map_mock, runner):
             views,
             target_dir=Path("looker-hub"),
             namespace="test_namespace",
+            use_cloud_function=False,
         )
 
         assert Path("looker-hub/test_namespace/datagroups").exists()
@@ -245,6 +244,7 @@ def test_skips_non_table_views(runner):
             views,
             target_dir=Path("looker-hub"),
             namespace="test_namespace",
+            use_cloud_function=False,
         )
 
         assert not Path("looker-hub/test_namespace/datagroups").exists()
@@ -309,6 +309,7 @@ def test_only_generates_one_datagroup_for_references_to_same_table(
             views,
             target_dir=Path("looker-hub"),
             namespace="test_namespace",
+            use_cloud_function=False,
         )
 
         assert Path(namespace_dir / "datagroups").exists()

--- a/tests/test_datagroups.py
+++ b/tests/test_datagroups.py
@@ -23,11 +23,48 @@ class MockTable(bigquery.Table):
     table_type: str
 
 
-@patch("google.cloud.bigquery.Table")
-@patch("google.cloud.bigquery.Table")
-@patch("google.cloud.bigquery.Client")
+class MockDryRun:
+    """Mock dryrun.DryRun."""
+
+    def __init__(
+        self,
+        sql=None,
+        project=None,
+        dataset=None,
+        table=None,
+    ):
+        self.sql = sql
+        self.project = project
+        self.dataset = dataset
+        self.table = table
+
+    def get_table_metadata(self):
+        """Mock dryrun.DryRun.get_table_metadata"""
+        full_table_id = f"{self.project}.{self.dataset}.{self.table}"
+
+        if full_table_id == "mozdata.analysis.test_table":
+            return {"tableType": "TABLE", "friendlyName": "Test Table"}
+        elif full_table_id == "moz-fx-data-shared-prod.analysis.view_1_source":
+            return {"tableType": "TABLE", "friendlyName": "View Source Table"}
+        elif full_table_id == "mozdata.analysis.view_1":
+            return {"tableType": "VIEW", "friendlyName": "Test View"}
+        elif full_table_id == "mozdata.analysis.test_table":
+            return {"tableType": "TABLE", "friendlyName": "Test Table"}
+        elif full_table_id == "mozdata.analysis.test_table_2":
+            return {"tableType": "TABLE", "friendlyName": "Test Table 2"}
+        elif full_table_id == "mozdata.analysis.view_1":
+            return {"tableType": "VIEW", "friendlyName": "Test View"}
+        elif full_table_id == "mozdata.analysis.test_view_2":
+            return {"tableType": "VIEW", "friendlyName": "Test View"}
+        elif full_table_id == "moz-fx-data-shared-prod.analysis.source_table":
+            return {"tableType": "TABLE", "friendlyName": "Source Table"}
+
+        return {}
+
+
+@patch("generator.views.datagroups.DryRun", MockDryRun)
 @patch("generator.views.lookml_utils.get_bigquery_view_reference_map")
-def test_generates_datagroups(reference_map_mock, client, table_1, table_2, runner):
+def test_generates_datagroups(reference_map_mock, runner):
     table_1_expected = (
         FILE_HEADER
         + """datagroup: test_table_last_updated {
@@ -36,7 +73,7 @@ def test_generates_datagroups(reference_map_mock, client, table_1, table_2, runn
     FROM `mozdata`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
     WHERE table_schema = 'analysis'
     AND table_name = 'test_table' ;;
-  description: "Updates when mozdata:analysis.test_table is modified."
+  description: "Updates when mozdata.analysis.test_table is modified."
   max_cache_age: "24 hours"
 }"""
     )
@@ -49,7 +86,7 @@ def test_generates_datagroups(reference_map_mock, client, table_1, table_2, runn
     FROM `mozdata`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
     WHERE table_schema = 'analysis'
     AND table_name = 'test_table_2' ;;
-  description: "Updates when mozdata:analysis.test_table_2 is modified."
+  description: "Updates when mozdata.analysis.test_table_2 is modified."
   max_cache_age: "24 hours"
 }"""
     )
@@ -72,24 +109,6 @@ def test_generates_datagroups(reference_map_mock, client, table_1, table_2, runn
     ]
 
     with runner.isolated_filesystem():
-        table_1.project = "mozdata"
-        table_2.project = "mozdata"
-        table_1.dataset_id = "analysis"
-        table_2.dataset_id = "analysis"
-        table_1.table_type = "TABLE"
-        table_2.table_type = "TABLE"
-        table_1.full_table_id = "mozdata:analysis.test_table"
-        table_2.full_table_id = "mozdata:analysis.test_table_2"
-        table_1.table_id = "test_table"
-        table_2.table_id = "test_table_2"
-        table_1.friendly_name = "Test Table"
-        table_2.friendly_name = "Test Table 2"
-        tables = {
-            "mozdata.analysis.test_table": table_1,
-            "mozdata.analysis.test_table_2": table_2,
-        }
-        client.get_table = tables.get
-
         namespace_dir = Path("looker-hub/test_namespace")
         namespace_dir.mkdir(parents=True)
 
@@ -98,40 +117,32 @@ def test_generates_datagroups(reference_map_mock, client, table_1, table_2, runn
             views,
             target_dir=Path("looker-hub"),
             namespace="test_namespace",
-            client=client,
         )
 
         assert Path(namespace_dir / "datagroups").exists()
         assert Path(
-            namespace_dir / f"datagroups/{table_1.table_id}_last_updated.datagroup.lkml"
+            namespace_dir / "datagroups/test_table_last_updated.datagroup.lkml"
         ).exists()
         assert (
             Path(
-                namespace_dir
-                / f"datagroups/{table_1.table_id}_last_updated.datagroup.lkml"
+                namespace_dir / "datagroups/test_table_last_updated.datagroup.lkml"
             ).read_text()
             == table_1_expected
         )
         assert Path(
-            namespace_dir / f"datagroups/{table_2.table_id}_last_updated.datagroup.lkml"
+            namespace_dir / "datagroups/test_table_2_last_updated.datagroup.lkml"
         ).exists()
         assert (
             Path(
-                namespace_dir
-                / f"datagroups/{table_2.table_id}_last_updated.datagroup.lkml"
+                namespace_dir / "datagroups/test_table_2_last_updated.datagroup.lkml"
             ).read_text()
             == table_2_expected
         )
 
 
-@patch("google.cloud.bigquery.Table")
-@patch("google.cloud.bigquery.Table")
-@patch("google.cloud.bigquery.Table")
-@patch("google.cloud.bigquery.Client")
 @patch("generator.views.lookml_utils.get_bigquery_view_reference_map")
-def test_generates_datagroups_with_tables_and_views(
-    reference_map_mock, client, table_1, view_1, view_1_source_table, runner
-):
+@patch("generator.views.datagroups.DryRun", MockDryRun)
+def test_generates_datagroups_with_tables_and_views(reference_map_mock, runner):
     table_1_expected = (
         FILE_HEADER
         + """datagroup: test_table_last_updated {
@@ -140,7 +151,7 @@ def test_generates_datagroups_with_tables_and_views(
     FROM `mozdata`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
     WHERE table_schema = 'analysis'
     AND table_name = 'test_table' ;;
-  description: "Updates when mozdata:analysis.test_table is modified."
+  description: "Updates when mozdata.analysis.test_table is modified."
   max_cache_age: "24 hours"
 }"""
     )
@@ -153,7 +164,7 @@ def test_generates_datagroups_with_tables_and_views(
     FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
     WHERE table_schema = 'analysis'
     AND table_name = 'view_1_source' ;;
-  description: "Updates when moz-fx-data-shared-prod:analysis.view_1_source is modified."
+  description: "Updates when moz-fx-data-shared-prod.analysis.view_1_source is modified."
   max_cache_age: "24 hours"
 }"""
     )
@@ -178,41 +189,11 @@ def test_generates_datagroups_with_tables_and_views(
     ]
 
     with runner.isolated_filesystem():
-        table_1.project = "mozdata"
-        table_1.dataset_id = "analysis"
-        table_1.table_type = "TABLE"
-        table_1.full_table_id = "mozdata:analysis.test_table"
-        table_1.table_id = "test_table"
-        table_1.friendly_name = "Test Table"
-
-        view_1.project = "mozdata"
-        view_1.dataset_id = "analysis"
-        view_1.table_type = "VIEW"
-        view_1.full_table_id = "mozdata:analysis.view_1"
-        view_1.table_id = "view_1"
-        view_1.friendly_name = "Test View"
-
-        view_1_source_table.project = "moz-fx-data-shared-prod"
-        view_1_source_table.dataset_id = "analysis"
-        view_1_source_table.table_type = "TABLE"
-        view_1_source_table.full_table_id = (
-            "moz-fx-data-shared-prod:analysis.view_1_source"
-        )
-        view_1_source_table.table_id = "view_1_source"
-        view_1_source_table.friendly_name = "View Source Table"
-
         reference_map_mock.return_value = {
             "analysis": {
                 "view_1": [["moz-fx-data-shared-prod", "analysis", "view_1_source"]]
             }
         }
-
-        tables = {
-            "mozdata.analysis.test_table": table_1,
-            "mozdata.analysis.view_1": view_1,
-            "moz-fx-data-shared-prod.analysis.view_1_source": view_1_source_table,
-        }
-        client.get_table = tables.get
 
         namespace_dir = Path("looker-hub/test_namespace")
         namespace_dir.mkdir(parents=True)
@@ -220,35 +201,31 @@ def test_generates_datagroups_with_tables_and_views(
             views,
             target_dir=Path("looker-hub"),
             namespace="test_namespace",
-            client=client,
         )
 
         assert Path("looker-hub/test_namespace/datagroups").exists()
         assert Path(
-            namespace_dir / f"datagroups/{table_1.table_id}_last_updated.datagroup.lkml"
+            namespace_dir / "datagroups/test_table_last_updated.datagroup.lkml"
         ).exists()
         assert (
             Path(
-                namespace_dir
-                / f"datagroups/{table_1.table_id}_last_updated.datagroup.lkml"
+                namespace_dir / "datagroups/test_table_last_updated.datagroup.lkml"
             ).read_text()
             == table_1_expected
         )
         assert Path(
-            namespace_dir
-            / f"datagroups/{view_1_source_table.table_id}_last_updated.datagroup.lkml"
+            namespace_dir / "datagroups/view_1_source_last_updated.datagroup.lkml"
         ).exists()
         assert (
             Path(
-                namespace_dir
-                / f"datagroups/{view_1_source_table.table_id}_last_updated.datagroup.lkml"
+                namespace_dir / "datagroups/view_1_source_last_updated.datagroup.lkml"
             ).read_text()
             == source_table_expected
         )
 
 
-@patch("google.cloud.bigquery.Client")
-def test_skips_non_table_views(client, runner):
+@patch("generator.views.datagroups.DryRun", MockDryRun)
+def test_skips_non_table_views(runner):
     views = [
         EventsView(
             namespace="test_namespace",
@@ -268,19 +245,15 @@ def test_skips_non_table_views(client, runner):
             views,
             target_dir=Path("looker-hub"),
             namespace="test_namespace",
-            client=client,
         )
 
         assert not Path("looker-hub/test_namespace/datagroups").exists()
 
 
-@patch("google.cloud.bigquery.Table")
-@patch("google.cloud.bigquery.Table")
-@patch("google.cloud.bigquery.Table")
-@patch("google.cloud.bigquery.Client")
+@patch("generator.views.datagroups.DryRun", MockDryRun)
 @patch("generator.views.lookml_utils.get_bigquery_view_reference_map")
 def test_only_generates_one_datagroup_for_references_to_same_table(
-    reference_map_mock, client, view_1, view_2, view_source_table, runner
+    reference_map_mock, runner
 ):
     expected = (
         FILE_HEADER
@@ -290,7 +263,7 @@ def test_only_generates_one_datagroup_for_references_to_same_table(
     FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
     WHERE table_schema = 'analysis'
     AND table_name = 'source_table' ;;
-  description: "Updates when moz-fx-data-shared-prod:analysis.source_table is modified."
+  description: "Updates when moz-fx-data-shared-prod.analysis.source_table is modified."
   max_cache_age: "24 hours"
 }"""
     )
@@ -322,42 +295,12 @@ def test_only_generates_one_datagroup_for_references_to_same_table(
     ]
 
     with runner.isolated_filesystem():
-        view_1.project = "mozdata"
-        view_1.dataset_id = "analysis"
-        view_1.table_type = "VIEW"
-        view_1.full_table_id = "mozdata:analysis.view_1"
-        view_1.table_id = "view_1"
-        view_1.friendly_name = "Test View"
-
-        view_2.project = "mozdata"
-        view_2.dataset_id = "analysis"
-        view_2.table_type = "VIEW"
-        view_2.full_table_id = "mozdata:analysis.test_view_2"
-        view_2.table_id = "view_2"
-        view_2.friendly_name = "Test View"
-
-        view_source_table.project = "moz-fx-data-shared-prod"
-        view_source_table.dataset_id = "analysis"
-        view_source_table.table_type = "TABLE"
-        view_source_table.full_table_id = (
-            "moz-fx-data-shared-prod:analysis.source_table"
-        )
-        view_source_table.table_id = "source_table"
-        view_source_table.friendly_name = "Source Table"
-
         reference_map_mock.return_value = {
             "analysis": {
                 "view_1": [["moz-fx-data-shared-prod", "analysis", "source_table"]],
                 "view_2": [["moz-fx-data-shared-prod", "analysis", "source_table"]],
             }
         }
-
-        tables = {
-            "mozdata.analysis.view_1": view_1,
-            "mozdata.analysis.view_2": view_2,
-            "moz-fx-data-shared-prod.analysis.source_table": view_source_table,
-        }
-        client.get_table = tables.get
 
         namespace_dir = Path("looker-hub/test_namespace")
         namespace_dir.mkdir(parents=True)
@@ -366,7 +309,6 @@ def test_only_generates_one_datagroup_for_references_to_same_table(
             views,
             target_dir=Path("looker-hub"),
             namespace="test_namespace",
-            client=client,
         )
 
         assert Path(namespace_dir / "datagroups").exists()
@@ -375,7 +317,7 @@ def test_only_generates_one_datagroup_for_references_to_same_table(
             Path(
                 namespace_dir
                 / "datagroups"
-                / f"{view_source_table.table_id}_last_updated.datagroup.lkml"
+                / "source_table_last_updated.datagroup.lkml"
             ).read_text()
             == expected
         )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -13,16 +13,13 @@ class MockDryRun:
     """Mock dryrun.DryRun."""
 
     def __init__(
-        self,
-        sql=None,
-        project=None,
-        dataset=None,
-        table=None,
+        self, sql=None, project=None, dataset=None, table=None, use_cloud_function=False
     ):
         self.sql = sql
         self.project = project
         self.dataset = dataset
         self.table = table
+        self.use_cloud_function = use_cloud_function
 
     def get_table_schema(self):
         """Mock dryrun.DryRun.get_table_schema"""
@@ -200,7 +197,7 @@ def test_view_lookml(events_view):
         ],
     }
 
-    actual = events_view.to_lookml(None)
+    actual = events_view.to_lookml(None, False)
     print_and_test(expected=expected, actual=actual)
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -177,8 +177,8 @@ def test_view_lookml(events_view):
             ),
             SchemaField("event_id", "STRING"),
         ]
-    )
-    actual = events_view.to_lookml(mock_bq_client, None)
+    ) # todo
+    actual = events_view.to_lookml(None)
     print_and_test(expected=expected, actual=actual)
 
 
@@ -210,5 +210,5 @@ def test_explore_lookml(time_partitioning_group, events_explore):
         },
     ]
 
-    actual = events_explore.to_lookml(None, None)
+    actual = events_explore.to_lookml(None)
     print_and_test(expected=expected, actual=actual)

--- a/tests/test_funnel_analysis.py
+++ b/tests/test_funnel_analysis.py
@@ -27,7 +27,7 @@ def funnel_analysis_view():
 @pytest.fixture()
 def funnel_analysis_explore(tmp_path, funnel_analysis_view):
     (tmp_path / "funnel_analysis.view.lkml").write_text(
-        lkml.dump(funnel_analysis_view.to_lookml(None))
+        lkml.dump(funnel_analysis_view.to_lookml(None, False))
     )
     return FunnelAnalysisExplore(
         "funnel_analysis",
@@ -284,7 +284,7 @@ def test_view_lookml(funnel_analysis_view):
             },
         ],
     }
-    actual = funnel_analysis_view.to_lookml(None)
+    actual = funnel_analysis_view.to_lookml(None, False)
 
     print_and_test(expected=expected, actual=actual)
 

--- a/tests/test_funnel_analysis.py
+++ b/tests/test_funnel_analysis.py
@@ -1,5 +1,4 @@
 from textwrap import dedent
-from unittest.mock import Mock
 
 import lkml
 import pytest

--- a/tests/test_funnel_analysis.py
+++ b/tests/test_funnel_analysis.py
@@ -28,7 +28,7 @@ def funnel_analysis_view():
 @pytest.fixture()
 def funnel_analysis_explore(tmp_path, funnel_analysis_view):
     (tmp_path / "funnel_analysis.view.lkml").write_text(
-        lkml.dump(funnel_analysis_view.to_lookml(Mock(), None))
+        lkml.dump(funnel_analysis_view.to_lookml(None))
     )
     return FunnelAnalysisExplore(
         "funnel_analysis",
@@ -285,7 +285,7 @@ def test_view_lookml(funnel_analysis_view):
             },
         ],
     }
-    actual = funnel_analysis_view.to_lookml(Mock(), None)
+    actual = funnel_analysis_view.to_lookml(None)
 
     print_and_test(expected=expected, actual=actual)
 
@@ -318,5 +318,5 @@ def test_explore_lookml(funnel_analysis_explore):
         {"name": "event_names", "hidden": "yes"},
     ]
 
-    actual = funnel_analysis_explore.to_lookml(None, None)
+    actual = funnel_analysis_explore.to_lookml(None)
     print_and_test(expected=expected, actual=actual)

--- a/tests/test_glean_ping_view.py
+++ b/tests/test_glean_ping_view.py
@@ -9,16 +9,13 @@ class MockDryRun:
     """Mock dryrun.DryRun."""
 
     def __init__(
-        self,
-        sql=None,
-        project=None,
-        dataset=None,
-        table=None,
+        self, sql=None, project=None, dataset=None, table=None, use_cloud_function=False
     ):
         self.sql = sql
         self.project = project
         self.dataset = dataset
         self.table = table
+        self.use_cloud_function = use_cloud_function
 
     def get_table_schema(self):
         """Mock dryrun.DryRun.get_table_schema"""
@@ -103,7 +100,7 @@ def test_kebab_case(mock_glean_ping):
         "dash_name",
         [{"channel": "release", "table": "mozdata.glean_app.dash_name"}],
     )
-    lookml = view.to_lookml("glean-app")
+    lookml = view.to_lookml("glean-app", False)
     assert len(lookml["views"]) == 1
     assert len(lookml["views"][0]["dimensions"]) == 1
     assert (
@@ -146,7 +143,7 @@ def test_url_metric(mock_glean_ping):
         "dash_name",
         [{"channel": "release", "table": "mozdata.glean_app.dash_name"}],
     )
-    lookml = view.to_lookml("glean-app")
+    lookml = view.to_lookml("glean-app", False)
     assert len(lookml["views"]) == 1
     assert len(lookml["views"][0]["dimensions"]) == 1
     assert (
@@ -188,7 +185,7 @@ def test_datetime_metric(mock_glean_ping):
         "dash_name",
         [{"channel": "release", "table": "mozdata.glean_app.dash_name"}],
     )
-    lookml = view.to_lookml("glean-app")
+    lookml = view.to_lookml("glean-app", False)
     assert len(lookml["views"]) == 1
     assert len(lookml["views"][0]["dimension_groups"]) == 1
     assert (
@@ -237,7 +234,7 @@ def test_undeployed_probe(mock_glean_ping):
         "dash_name",
         [{"channel": "release", "table": "mozdata.glean_app.dash_name"}],
     )
-    lookml = view.to_lookml("glean-app")
+    lookml = view.to_lookml("glean-app", False)
     # In addition to the table view, each labeled counter adds a join view and a suggest
     # view. Expect 3 views, because 1 for the table view, 2 added for fun.counter_metric
     # because it's in the table schema, and 0 added for fun.counter_metric2 because it's

--- a/tests/test_glean_ping_view.py
+++ b/tests/test_glean_ping_view.py
@@ -7,15 +7,27 @@ from mozilla_schema_generator.probes import GleanProbe
 from generator.views import GleanPingView
 
 
-class MockClient: # todo
-    """Mock bigquery.Client."""
+class MockDryRun:
+    """Mock dryrun.DryRun."""
+    def __init__(
+        self,
+        sql=None,
+        project=None,
+        dataset=None,
+        table=None,
+    ):
+        self.sql = sql
+        self.project = project
+        self.dataset = dataset
+        self.table = table
 
-    def get_table(self, table_ref):
-        """Mock bigquery.Client.get_table."""
+    def get_table_schema(self):
+        """Mock dryrun.DryRun.get_table_schema"""
+        table_id = f"{self.project}.{self.dataset}.{self.table}"
 
-        if table_ref == "mozdata.glean_app.dash_name":
+        if table_id == "mozdata.glean_app.dash_name":
             return bigquery.Table(
-                table_ref,
+                table_id,
                 schema=[
                     SchemaField(
                         "metrics",
@@ -58,7 +70,7 @@ class MockClient: # todo
                 ],
             )
 
-        raise ValueError(f"Table not found: {table_ref}")
+        raise ValueError(f"Table not found: {table_id}")
 
 
 @patch("generator.views.glean_ping_view.GleanPing")
@@ -87,7 +99,7 @@ def test_kebab_case(mock_glean_ping):
         ),
     ]
     mock_glean_ping.return_value = glean_app
-    mock_bq_client = MockClient()
+    mock_bq_client = MockDryRun()
     view = GleanPingView(
         "glean_app",
         "dash_name",
@@ -128,7 +140,7 @@ def test_url_metric(mock_glean_ping):
         ),
     ]
     mock_glean_ping.return_value = glean_app
-    mock_bq_client = MockClient()
+    mock_bq_client = MockDryRun()
     view = GleanPingView(
         "glean_app",
         "dash_name",

--- a/tests/test_glean_ping_view.py
+++ b/tests/test_glean_ping_view.py
@@ -7,7 +7,7 @@ from mozilla_schema_generator.probes import GleanProbe
 from generator.views import GleanPingView
 
 
-class MockClient:
+class MockClient: # todo
     """Mock bigquery.Client."""
 
     def get_table(self, table_ref):
@@ -93,7 +93,7 @@ def test_kebab_case(mock_glean_ping):
         "dash_name",
         [{"channel": "release", "table": "mozdata.glean_app.dash_name"}],
     )
-    lookml = view.to_lookml(mock_bq_client, "glean-app")
+    lookml = view.to_lookml("glean-app")
     assert len(lookml["views"]) == 1
     assert len(lookml["views"][0]["dimensions"]) == 1
     assert (

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -429,13 +429,31 @@ class MockDryRun:
                 },
             ]
         if table_ref == "mozdata.fail.duplicate_dimension":
-            return bigquery.Table(
-                table_ref,
-                schema=[
-                    SchemaField(name="parsed_timestamp", field_type="TIMESTAMP"),
-                    SchemaField(name="parsed_date", field_type="DATE"),
-                ],
-            )
+            return [
+                {
+                    "name": "parsed_timestamp",
+                    "type": "TIMESTAMP",
+                },
+                {
+                    "name": "parsed_date",
+                    "type": "DATE",
+                },
+            ]
+        if table_ref == "mozdata.pass.duplicate_event_dimension":
+            return [
+                {
+                    "name": "submission_timestamp",
+                    "type": "TIMESTAMP",
+                },
+                {
+                    "name": "event_timestamp",
+                    "type": "TIMESTAMP",
+                },
+                {
+                    "name": "event",
+                    "type": "STRING",
+                },
+            ]
         if table_ref == "mozdata.fail.duplicate_client":
             return [
                 {
@@ -1891,8 +1909,9 @@ def test_duplicate_dimension_event(runner, glean_apps, tmp_path):
         )
     )
     with runner.isolated_filesystem():
-        with patch("google.cloud.bigquery.Client", MockClient):
-            _lookml(open(namespaces), glean_apps, "looker-hub/")
+        mock_dryrun = functools.partial(MockDryRun, None, False, None)
+        namespaces = tmp_path / "namespaces.yaml"
+        _lookml(open(namespaces), glean_apps, "looker-hub/", dryrun=mock_dryrun)
         expected = {
             "views": [
                 {

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -30,16 +30,13 @@ class MockDryRun:
     """Mock dryrun.DryRun."""
 
     def __init__(
-        self,
-        sql=None,
-        project=None,
-        dataset=None,
-        table=None,
+        self, sql=None, project=None, dataset=None, table=None, use_cloud_function=False
     ):
         self.sql = sql
         self.project = project
         self.dataset = dataset
         self.table = table
+        self.use_cloud_function = use_cloud_function
 
     def get_table_metadata(self):
         """Mock dryrun.DryRun.get_table_metadata"""

--- a/tests/test_operational_monitoring.py
+++ b/tests/test_operational_monitoring.py
@@ -15,16 +15,13 @@ class MockDryRun:
     """Mock dryrun.DryRun."""
 
     def __init__(
-        self,
-        sql=None,
-        project=None,
-        dataset=None,
-        table=None,
+        self, sql=None, project=None, dataset=None, table=None, use_cloud_function=False
     ):
         self.sql = sql
         self.project = project
         self.dataset = dataset
         self.table = table
+        self.use_cloud_function = use_cloud_function
 
     def get_table_schema(self):
         """Mock dryrun.DryRun.get_table_schema"""
@@ -71,7 +68,7 @@ def operational_monitoring_view():
 @patch("generator.views.lookml_utils.DryRun", MagicMock)
 def operational_monitoring_explore(tmp_path, operational_monitoring_view):
     (tmp_path / "fission.view.lkml").write_text(
-        lkml.dump(operational_monitoring_view.to_lookml(None))
+        lkml.dump(operational_monitoring_view.to_lookml(None, False))
     )
     return OperationalMonitoringExplore(
         "fission",
@@ -201,7 +198,7 @@ def test_view_lookml(operational_monitoring_view):
             }
         ]
     }
-    actual = operational_monitoring_view.to_lookml(None)
+    actual = operational_monitoring_view.to_lookml(None, False)
     print(actual)
 
     print_and_test(expected=expected, actual=actual)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,6 @@
 """Utility functions for tests."""
 
 import pprint
-from typing import List
-
-from google.cloud import bigquery
-from google.cloud.bigquery.schema import SchemaField
 
 
 def get_differences(expected, result, path="", sep="."):
@@ -79,16 +75,3 @@ def print_and_test(expected, result=None, actual=None):
     print("\n".join([" - ".join(v) for v in get_differences(expected, result)]))
 
     assert result == expected
-
-
-def get_mock_bq_client(schema: List[SchemaField]):
-    """Get a mock BQ client that will return a specified schema."""
-
-    class MockClient:
-        """Mock bigquery.Client."""
-
-        def get_table(self, table_ref):
-            """Mock bigquery.Client.get_table."""
-            return bigquery.Table(table_ref, schema=schema)
-
-    return MockClient()


### PR DESCRIPTION
Depends on https://github.com/mozilla-services/cloudops-infra/pull/5769

This adds a `use_cloud_function` option for lookml-generator to use the dryrun Cloud Function for the LookML generation. This solves multiple problems:
* Generating LookML for restricted tables. When running generation locally with user credentials the generation currently fails as access is restricted to tables such as `ads`
* Generating LookML in CI. This is desirable to have to generate change diffs.

I generated a diff here: https://github.com/mozilla/looker-hub/compare/test-lookml-generation-dryrun?expand=1
The main changes are in the descriptions to use `.` instead of `:` for table IDs. `user_journey` artifacts show up as deleted which is [expected since none are defined in `custom-namespaces.yaml`](https://github.com/mozilla/lookml-generator/blob/8a5bee98eeeef7ded36f739cb4b06677247789e7/custom-namespaces.yaml#L1584-L1588)

The dry run function cannot generate `operational_monitoring` namespace information as this requires querying information from some tables in BigQuery. When we start using this in CI to generate diff, this namespace will need to be skipped using the `--ignore` option.