### PR TITLE
Allow same names for dimensions and time dimension groups in generated views

### DIFF
--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -117,25 +117,25 @@ def _generate_dimensions(client: bigquery.Client, table: str) -> List[Dict[str, 
     """
     dimensions = {}
     for dimension in _generate_dimensions_helper(client.get_table(table).schema):
-        name = dimension["name"]
+        name_key = dimension["name"]
 
         # This prevents `time` dimension groups from overwriting other dimensions below
         if dimension.get("type") == "time":
-            name += "_time"
+            name_key += "_time"
 
         # overwrite duplicate "submission", "end", "start" dimension group, thus picking the
         # last value sorted by field name, which is submission_timestamp
         # See also https://github.com/mozilla/lookml-generator/issues/471
         if (
-            name in dimensions
-            and name != "submission"
-            and not name.endswith("end")
-            and not name.endswith("start")
+            name_key in dimensions
+            and dimension["name"] != "submission"
+            and not dimension["name"].endswith("end")
+            and not dimension["name"].endswith("start")
         ):
             raise click.ClickException(
-                f"duplicate dimension {name!r} for table {table!r}"
+                f"duplicate dimension {name_key!r} for table {table!r}"
             )
-        dimensions[name] = dimension
+        dimensions[name_key] = dimension
     return list(dimensions.values())
 
 
@@ -147,23 +147,23 @@ def _generate_dimensions_from_query(
     schema = client.query(query, job_config=job_config).schema
     dimensions = {}
     for dimension in _generate_dimensions_helper(schema or []):
-        name = dimension["name"]
+        name_key = dimension["name"]
 
         # This prevents `time` dimension groups from overwriting other dimensions below
         if dimension.get("type") == "time":
-            name += "_time"
+            name_key += "_time"
 
         # overwrite duplicate "submission", "end", "start" dimension group, thus picking the
         # last value sorted by field name, which is submission_timestamp
         # See also https://github.com/mozilla/lookml-generator/issues/471
         if (
-            name in dimensions
-            and name != "submission"
-            and not name.endswith("end")
-            and not name.endswith("start")
+            name_key in dimensions
+            and dimension["name"] != "submission"
+            and not dimension["name"].endswith("end")
+            and not dimension["name"].endswith("start")
         ):
-            raise click.ClickException(f"duplicate dimension {name!r} in query")
-        dimensions[name] = dimension
+            raise click.ClickException(f"duplicate dimension {name_key!r} in query")
+        dimensions[name_key] = dimension
     return list(dimensions.values())
 
 

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -126,11 +126,13 @@ def _generate_dimensions(client: bigquery.Client, table: str) -> List[Dict[str, 
         # overwrite duplicate "submission", "end", "start" dimension group, thus picking the
         # last value sorted by field name, which is submission_timestamp
         # See also https://github.com/mozilla/lookml-generator/issues/471
-        if (
-            name_key in dimensions
-            and dimension["name"] != "submission"
-            and not dimension["name"].endswith("end")
-            and not dimension["name"].endswith("start")
+        if name_key in dimensions and not (
+            dimension.get("type") == "time"
+            and (
+                dimension["name"] == "submission"
+                or dimension["name"].endswith("end")
+                or dimension["name"].endswith("start")
+            )
         ):
             raise click.ClickException(
                 f"duplicate dimension {name_key!r} for table {table!r}"
@@ -156,11 +158,13 @@ def _generate_dimensions_from_query(
         # overwrite duplicate "submission", "end", "start" dimension group, thus picking the
         # last value sorted by field name, which is submission_timestamp
         # See also https://github.com/mozilla/lookml-generator/issues/471
-        if (
-            name_key in dimensions
-            and dimension["name"] != "submission"
-            and not dimension["name"].endswith("end")
-            and not dimension["name"].endswith("start")
+        if name_key in dimensions and not (
+            dimension.get("type") == "time"
+            and (
+                dimension["name"] == "submission"
+                or dimension["name"].endswith("end")
+                or dimension["name"].endswith("start")
+            )
         ):
             raise click.ClickException(f"duplicate dimension {name_key!r} in query")
         dimensions[name_key] = dimension


### PR DESCRIPTION
Alternative to https://github.com/mozilla/lookml-generator/pull/1007 that would fix https://github.com/mozilla/bigquery-etl/issues/5903, implements suggestion from https://github.com/mozilla/lookml-generator/pull/1007#discussion_r1678304804.

This approach seems to be minimally invasive and generalized, without hardcoding table names, allowing to unblock https://github.com/mozilla/bigquery-etl/issues/5903.

