### PR TITLE
Add custom namespaces to surface tables in Looker

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1209,6 +1209,14 @@ monitoring:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.monitoring_derived.event_error_monitoring_aggregates_v1
+    mlops_job_cost_per_job:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.monitoring_derived.outerbounds_cost_per_flow_v1
+    mlops_job_cost_per_job_run:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.monitoring_derived.outerbounds_cost_per_flow_run_v1
   explores:
     column_size:
       type: ping_explore


### PR DESCRIPTION
I just added these two views in bigquery-etl. This PR should surface them in Looker such that they can be included in dashboards. 