### PR TITLE
Change www_site_downloads to shared prod

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1350,7 +1350,7 @@ websites:
     ga4_www_site_downloads:
       type: table_view
       tables:
-        - table: moz-fx-data-marketing-prod.mozilla_org.www_site_downloads
+        - table: moz-fx-data-shared-prod.mozilla_org.www_site_downloads
     ga4_sessions:
       type: table_view
       tables:


### PR DESCRIPTION
I think this was missed in https://github.com/mozilla/lookml-generator/pull/1025/.  lookml is currently failing with `Not found: Dataset moz-fx-data-marketing-prod:mozilla_org`