### PR TITLE
Add limited historical Google Search Console views (DENG-4329)

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1399,6 +1399,14 @@ websites:
       type: table_view
       tables:
         - table: mozdata.google_search_console.search_impressions_by_site
+    limited_historical_google_search_console_by_page:
+      type: table_view
+      tables:
+        - table: mozdata.google_search_console.limited_historical_search_impressions_by_page
+    limited_historical_google_search_console_by_site:
+      type: table_view
+      tables:
+        - table: mozdata.google_search_console.limited_historical_search_impressions_by_site
 marketing:
   glean_app: false
   pretty_name: Marketing


### PR DESCRIPTION
## [DENG-4329](https://mozilla-hub.atlassian.net/browse/DENG-4329): Google Search Console data synced by Fivetran is not comparable to the data exported by Google

Depends on mozilla/bigquery-etl#6027.