### PR TITLE
DENG-4691 Add custom namespace to surface rayserve cost views in looker

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1241,6 +1241,10 @@ monitoring:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.monitoring_derived.outerbounds_cost_per_flow_run_v1
+    mlops_rayserve_cost_fakespot_tenant:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.monitoring_derived.rayserve_cost_fakespot_tenant_v1
   explores:
     column_size:
       type: ping_explore


### PR DESCRIPTION
I added a view in bigquery-etl via https://github.com/mozilla/bigquery-etl/pull/6146
This PR should surface it in Looker such that it can be included in dashboards.