### PR TITLE
feat(): add new_profiles table views to mobile product namespaces

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -824,6 +824,10 @@ firefox_ios:
       type: table_view
       tables:
         - table: mozdata.firefox_ios.firefox_ios_clients
+    new_profiles:
+      type: table_view
+      tables:
+        - table: mozdata.firefox_ios.new_profiles
   explores:
     feature_usage_metrics:
       type: table_explore
@@ -837,11 +841,30 @@ firefox_ios:
       type: table_explore
       views:
         base_view: clients_activation
+focus_ios:
+  owners:
+    - loines@mozilla.com
+    - rbaffourawuah@mozilla.com
+    - kik@mozilla.com
+  views:
+    new_profiles:
+      type: table_view
+      tables:
+        - table: mozdata.focus_ios.new_profiles
+klar_ios:
+  owners:
+    - loines@mozilla.com
+    - rbaffourawuah@mozilla.com
+    - kik@mozilla.com
+  views:
+    new_profiles:
+      type: table_view
+      tables:
+        - table: mozdata.klar_ios.new_profiles
 fenix:
   pretty_name: Firefox Android
   owners:
     - vzare@mozilla.com
-    - ksiegler@mozilla.com
     - rbaffourawuah@mozilla.com
     - vsabino@mozilla.com
     - kik@mozilla.com
@@ -870,6 +893,10 @@ fenix:
       type: table_view
       tables:
         - table: mozdata.fenix.firefox_android_clients
+    new_profiles:
+      type: table_view
+      tables:
+        - table: mozdata.fenix.new_profiles
   explores:
     feature_usage_metrics:
       type: table_explore
@@ -879,12 +906,26 @@ fenix:
       type: table_explore
       views:
         base_view: feature_usage_events
-focus_ios:
-  owners:
-    - loines@mozilla.com
 focus_android:
   owners:
     - loines@mozilla.com
+    - rbaffourawuah@mozilla.com
+    - kik@mozilla.com
+  views:
+    new_profiles:
+      type: table_view
+      tables:
+        - table: mozdata.focus_android.new_profiles
+klar_android:
+  owners:
+    - loines@mozilla.com
+    - rbaffourawuah@mozilla.com
+    - kik@mozilla.com
+  views:
+    new_profiles:
+      type: table_view
+      tables:
+        - table: mozdata.klar_android.new_profiles
 newtab:
   glean_app: false
   connection: bigquery-oauth


### PR DESCRIPTION
# feat(): add new_profiles table views to mobile product namespaces

new_profiles aggregate table view added for the following mobile products:

- `fenix`
- `focus_android`
- `klar_android`
- `firefox_ios`
- `focus_ios`
- `klar_ios`