### PR TITLE
DENG-4691 Add custom namespace for fakespot cost (prod) views in looker

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1310,6 +1310,10 @@ monitoring:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.monitoring_derived.rayserve_cost_fakespot_tenant_v1
+    mlops_rayserve_cost_fakespot_tenant_prod:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.monitoring_derived.rayserve_cost_fakespot_tenant_prod_v1
   explores:
     column_size:
       type: ping_explore


### PR DESCRIPTION
I added a view in bigquery-etl via https://github.com/mozilla/bigquery-etl/pull/6163

This PR should surface it in Looker such that it can be included in dashboards.

This task is tracked via JIRA issue https://mozilla-hub.atlassian.net/browse/DENG-4691