### PR TITLE
fxci: add some measures and remove unnecessary table explores

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1714,7 +1714,7 @@ fxci:
     task_run_costs:
       type: table_view
       tables:
-        - table: moz-fx-data-shared-prod.fxci_derived.task_run_costs_v1
+        - table: moz-fx-data-shared-prod.fxci.task_run_costs
       measures:
         total_cost:
           type: sum
@@ -1723,7 +1723,7 @@ fxci:
     worker_costs:
       type: table_view
       tables:
-        - table: moz-fx-data-shared-prod.fxci_derived.worker_costs_v1
+        - table: moz-fx-data-shared-prod.fxci.worker_costs
       measures:
         total_cost:
           type: sum

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1702,27 +1702,6 @@ fxci:
   owners:
     - ahalberstadt@mozilla.com
   glean_app: false
-  explores:
-    tasks:
-      type: table_explore
-      views:
-        base_view: tasks
-    task_runs:
-      type: table_explore
-      views:
-        base_view: task_runs
-    task_run_costs:
-      type: table_explore
-      views:
-        base_view: task_run_costs
-    worker_costs:
-      type: table_explore
-      views:
-        base_view: worker_costs
-    worker_metrics:
-      type: table_explore
-      views:
-        base_view: worker_metrics
   views:
     tasks:
       type: table_view

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1736,11 +1736,26 @@ fxci:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.fxci_derived.task_run_costs_v1
+      measures:
+        total_cost:
+          type: sum
+          value_format_name: usd
+          sql: "${run_cost}"
     worker_costs:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.fxci_derived.worker_costs_v1
+      measures:
+        total_cost:
+          type: sum
+          value_format_name: usd
+          sql: "${total_cost}"
     worker_metrics:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.fxci.worker_metrics_v1
+      measures:
+        total_uptime:
+          type: sum
+          value_format_name: seconds
+          sql: "${uptime}"


### PR DESCRIPTION
As I learn more about Looker, I realize I needed to create some explores
in the spoke project that join across these various views. I'll be
creating an explore that joins across the three "task" tables, an
explore that joins across the two "worker" tables, and possibly an
explore that joins everything?

With these new explores, I don't think there will be any use case for
keeping table specific explores lying around.