### PR TITLE
feat: deprecate funnel_retention_week_4 table views for fenix and firefox_ios as superseded by mobile_retention

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -804,10 +804,6 @@ firefox_ios:
     - rbaffourawuah@mozilla.com
     - vsabino@mozilla.com
   views:
-    funnel_retention_week_4:
-      type: table_view
-      tables:
-        - table: mozdata.firefox_ios.funnel_retention_week_4
     feature_usage_metrics:
       type: table_view
       tables:
@@ -849,10 +845,6 @@ fenix:
       type: table_view
       tables:
         - table: moz-fx-data-marketing-prod.google_play_store.Store_Performance_country_v1
-    funnel_retention_week_4:
-      type: table_view
-      tables:
-        - table: mozdata.fenix.funnel_retention_week_4
     android_onboarding:
       type: table_view
       tables:


### PR DESCRIPTION
# feat: deprecate funnel_retention_week_4 table views for fenix and firefox_ios as superseded by mobile_retention