### PR TITLE
Remove unused namespaces

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -31,4 +31,3 @@
 - hubs
 - relay_backend
 - gleanjs_docs
-- firefox_crashreporter

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -25,3 +25,10 @@
 - glean_dictionary
 - mach
 - "*_cirrus"
+- bedrock
+- firefox_desktop_background_tasks
+- firefox_desktop_background_defaultagent
+- hubs
+- relay_backend
+- gleanjs_docs
+- firefox_crashreporter


### PR DESCRIPTION
I did another run of [Henry](https://github.com/looker-open-source/henry) to see which namespaces haven't been used in the last 180 days. These namespaces seem safe to remove to reduce the number of Looker artifacts and gain some potential performance improvements