### PR TITLE
Set default sampling filter to 1% for metric definiton explores

### DIFF
--- a/generator/explores/metric_definitions_explore.py
+++ b/generator/explores/metric_definitions_explore.py
@@ -44,7 +44,9 @@ class MetricDefinitionsExplore(Explore):
 
         explore_lookml: Dict[str, Any] = {
             "name": self.name,
-            "always_filter": {"filters": [{"submission_date": "7 days"}]},
+            "always_filter": {
+                "filters": [{"submission_date": "7 days"}, {"sampling": "1"}]
+            },
             # The base view is the only view that exposes the date and client_id fields.
             # All other views only expose the metric definitions.
             "fields": exposed_fields,


### PR DESCRIPTION
This is to increase performance of the Metric Definition explores. Setting sampling to 1% by default.