### PR TITLE
DENG-2407 Allow hiding generated explores

### DIFF
--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -25,7 +25,9 @@ class Explore:
         """Explore instance represented as a dict."""
         return {self.name: {"type": self.type, "views": self.views}}
 
-    def to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
+    def to_lookml(
+        self, v1_name: Optional[str], hidden: Optional[bool]
+    ) -> List[Dict[str, Any]]:
         """
         Generate LookML for this explore.
 
@@ -33,6 +35,8 @@ class Explore:
         `_to_lookml` takes precedence over these fields.
         """
         base_lookml = {}
+        if hidden:
+            base_lookml["hidden"] = "yes"
         base_view_name = next(
             (
                 view_name

--- a/generator/lookml.py
+++ b/generator/lookml.py
@@ -77,6 +77,9 @@ def _generate_explore(
     explore_by_type = EXPLORE_TYPES[explore_info["type"]].from_dict(
         explore_name, explore_info, views_dir
     )
+
+    hidden = explore_info.get("hidden", False)
+
     file_lookml = {
         # Looker validates all included files,
         # so if we're not explicit about files here, validation takes
@@ -85,7 +88,7 @@ def _generate_explore(
             f"/looker-hub/{namespace}/views/{view}.view.lkml"
             for view in explore_by_type.get_dependent_views()
         ],
-        "explores": explore_by_type.to_lookml(v1_name),
+        "explores": explore_by_type.to_lookml(v1_name, hidden),
     }
     path = out_dir / (explore_name + ".explore.lkml")
     # lkml.dump may return None, in which case write an empty file

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -219,5 +219,5 @@ def test_explore_lookml(time_partitioning_group, events_explore):
         },
     ]
 
-    actual = events_explore.to_lookml(None)
+    actual = events_explore.to_lookml(None, None)
     print_and_test(expected=expected, actual=actual)

--- a/tests/test_funnel_analysis.py
+++ b/tests/test_funnel_analysis.py
@@ -327,5 +327,5 @@ def test_explore_lookml(funnel_analysis_explore):
         {"name": "event_names", "hidden": "yes"},
     ]
 
-    actual = funnel_analysis_explore.to_lookml(None)
+    actual = funnel_analysis_explore.to_lookml(None, None)
     print_and_test(expected=expected, actual=actual)

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -111,6 +111,12 @@ def custom_namespaces(tmp_path):
                   tables:
                   - table: mozdata.private.events
             glean-app:
+              explores:
+                deprecated_ping:
+                  hidden: true
+                  type: glean_ping_explore
+                  views:
+                    base_view: deprecated_ping
               owners:
               - glean-app-owner2@allizom.com
             """
@@ -233,6 +239,14 @@ def generated_sql_uri(tmp_path):
             f"sql/moz-fx-data-shared-prod/{dataset}/"
             "baseline_clients_last_seen/metadata.yaml"
         )
+        paths[path] = content
+
+        content = f"""
+            references:
+              view.sql:
+              - moz-fx-data-shared-prod.{source_dataset}.deprecated_ping_v1
+            """
+        path = f"sql/moz-fx-data-shared-prod/{dataset}/deprecated_ping/metadata.yaml"
         paths[path] = content
 
     return paths_to_tar(dest, paths)
@@ -366,6 +380,11 @@ def test_namespaces_full(
                             "type": "growth_accounting_explore",
                             "views": {"base_view": "growth_accounting"},
                         },
+                        "deprecated_ping": {
+                            "hidden": True,
+                            "type": "glean_ping_explore",
+                            "views": {"base_view": "deprecated_ping"},
+                        },
                     },
                     "glean_app": True,
                     "owners": [
@@ -423,6 +442,32 @@ def test_namespaces_full(
                                 {
                                     "channel": "beta",
                                     "table": "mozdata.glean_app_beta.baseline",
+                                },
+                            ],
+                            "type": "table_view",
+                        },
+                        "deprecated_ping": {
+                            "tables": [
+                                {
+                                    "channel": "release",
+                                    "table": "mozdata.glean_app.deprecated_ping",
+                                },
+                                {
+                                    "channel": "beta",
+                                    "table": "mozdata.glean_app_beta.deprecated_ping",
+                                },
+                            ],
+                            "type": "glean_ping_view",
+                        },
+                        "deprecated_ping_table": {
+                            "tables": [
+                                {
+                                    "channel": "release",
+                                    "table": "mozdata.glean_app.deprecated_ping",
+                                },
+                                {
+                                    "channel": "beta",
+                                    "table": "mozdata.glean_app_beta.deprecated_ping",
                                 },
                             ],
                             "type": "table_view",
@@ -556,6 +601,14 @@ def test_get_looker_views(glean_apps, generated_sql_uri):
                 {"channel": "beta", "table": "mozdata.glean_app_beta.baseline"},
             ],
         ),
+        GleanPingView(
+            namespace,
+            "deprecated_ping",
+            [
+                {"channel": "release", "table": "mozdata.glean_app.deprecated_ping"},
+                {"channel": "beta", "table": "mozdata.glean_app_beta.deprecated_ping"},
+            ],
+        ),
         GrowthAccountingView(
             namespace,
             [
@@ -598,6 +651,14 @@ def test_get_looker_views(glean_apps, generated_sql_uri):
                     "table": "mozdata.glean_app_beta.baseline_clients_last_seen",
                     "channel": "beta",
                 },
+            ],
+        ),
+        TableView(
+            namespace,
+            "deprecated_ping_table",
+            [
+                {"table": "mozdata.glean_app.deprecated_ping", "channel": "release"},
+                {"table": "mozdata.glean_app_beta.deprecated_ping", "channel": "beta"},
             ],
         ),
     ]

--- a/tests/test_operational_monitoring.py
+++ b/tests/test_operational_monitoring.py
@@ -201,7 +201,7 @@ def test_explore_lookml(operational_monitoring_explore):
         }
     ]
 
-    actual = operational_monitoring_explore.to_lookml(None)
+    actual = operational_monitoring_explore.to_lookml(None, None)
     print_and_test(expected=expected, actual=actual)
 
 


### PR DESCRIPTION
This adds an option to make generated explores hidden.

This will be useful for https://mozilla-hub.atlassian.net/browse/DENG-2407 where we are deprecating custom ping in favor of `events` ping. Hiding the custom ping explore will make working with Looker less confusing to users. It will also ensure that no new dashboards are built with explore in question and existing ones will not break.

In order to hide autogenerated explore we'll need to put it in `custom-namespaces` with `hidden: true`. Specifically, for DENG-2407 this would look like:
```
accounts_backend:
  explores:
    accounts_events:
      hidden: true
      type: glean_ping_explore
      views:
        base_view: accounts_events
```