### PR TITLE
Add shared_private namespace for country customizations

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1373,6 +1373,7 @@ shared_private:
   pretty_name: Shared Private
   owners:
     - ascholtz@mozilla.com
+  spoke: looker-spoke-private
   views:
     countries:
       type: table_view

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1354,7 +1354,6 @@ shared:
   glean_app: false
   pretty_name: Shared
   owners:
-    - anicholson@mozilla.com
     - ascholtz@mozilla.com
   views:
     countries:
@@ -1369,6 +1368,16 @@ shared:
       type: table_view
       tables:
         - table: mozdata.telemetry.applications
+shared_private:
+  glean_app: false
+  pretty_name: Shared Private
+  owners:
+    - ascholtz@mozilla.com
+  views:
+    countries:
+      type: table_view
+      tables:
+        - table: mozdata.static.country_codes_v1
 websites:
   glean_app: false
   pretty_name: Websites


### PR DESCRIPTION
This is to fix https://mozilla.slack.com/archives/C01E8GDG80N/p1728324080900889

Currently, there are conflicting namespaces as `shared` already exists in spoke-default. The naming convention for private namespaces is to add a `_private` suffix. This will also resolve the conflict here.