### PR TITLE
Add `relay_backend` namespace

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1492,11 +1492,6 @@ relay:
       type: table_view
       tables:
         - table: mozdata.relay.active_subscription_ids
-relay_backend:
-  glean_app: true
-  owners:
-    - srose@mozilla.com
-  pretty_name: Firefox Relay Backend
 fivetran:
   glean_app: false
   owners:

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1492,6 +1492,11 @@ relay:
       type: table_view
       tables:
         - table: mozdata.relay.active_subscription_ids
+relay_backend:
+  glean_app: true
+  owners:
+    - srose@mozilla.com
+  pretty_name: Firefox Relay Backend
 fivetran:
   glean_app: false
   owners:

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -29,5 +29,4 @@
 - firefox_desktop_background_tasks
 - firefox_desktop_background_defaultagent
 - hubs
-- relay_backend
 - gleanjs_docs


### PR DESCRIPTION
There was a [request in Slack](https://mozilla.slack.com/archives/C03V75Q1KQS/p1728424127467039) for the Relay backend data to be made available in Looker.