### PR TITLE
DENG-5757 - add new view for metadata completeness to Looker

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1121,6 +1121,10 @@ monitoring:
     - wichan@mozilla.com
   pretty_name: Monitoring (Data Pipeline)
   views:
+    metadata_completeness: 
+      tables:
+        - table: mozdata.monitoring.metadata_completeness
+      type: table_view
     bigquery_tables_inventory:
       tables:
         - table: moz-fx-data-shared-prod.monitoring.bigquery_tables_inventory


### PR DESCRIPTION
This PR adds the new view "metadata_completeness" to Looker, referencing: mozdata.monitoring.metadata_completeness