### PR TITLE
Bug 1932210 - Add labeled_quantity glean metric type

### DIFF
--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -36,6 +36,7 @@ ALLOWED_TYPES = DISTRIBUTION_TYPES | {
     "uuid",
     "url",
     "text",
+    "labeled_quantity",
 }
 
 # Bug 1737656 - some metric types are exposed under different names


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1932210

Following the instructions in https://github.com/mozilla/glean/blob/main/docs/dev/core/new-metric-type/platform.md