### PR TITLE
feat: move bigeye_usage from operational_monitoring to monitoring namespace

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -9,26 +9,6 @@ operational_monitoring:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.operational_monitoring_derived.projects_v1
-    bigeye_usage:
-      type: table_view
-      tables:
-        - table: moz-fx-data-shared-prod.monitoring.bigeye_usage
-      measures:
-        cost:
-          type: sum
-          sql: "${cost}"
-        total_terabytes_processed:
-          type: sum
-          sql: "${total_terabytes_processed}"
-        total_terabytes_billed:
-          type: sum
-          sql: "${total_terabytes_billed}"
-        total_slot_ms:
-          type: sum
-          sql: "${total_slot_ms}"
-        task_duration:
-          type: sum
-          sql: "${task_duration}"
 combined_browser_metrics:
   glean_app: false
   owners:
@@ -1360,6 +1340,26 @@ monitoring:
       type: table_view
       tables:
         - table: mozdata.monitoring.airflow_user
+    bigeye_usage:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.monitoring.bigeye_usage
+      measures:
+        cost:
+          type: sum
+          sql: "${cost}"
+        total_terabytes_processed:
+          type: sum
+          sql: "${total_terabytes_processed}"
+        total_terabytes_billed:
+          type: sum
+          sql: "${total_terabytes_billed}"
+        total_slot_ms:
+          type: sum
+          sql: "${total_slot_ms}"
+        task_duration:
+          type: sum
+          sql: "${task_duration}"
     event_monitoring_live:
       type: table_view
       tables:


### PR DESCRIPTION
feat: move bigeye_usage from operational_monitoring to monitoring namespace