### PR TITLE
Remove experimentation search monitoring views

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1006,6 +1006,11 @@ experimentation:
       tables:
         - channel: release
           table: mozdata.telemetry.experiment_enrollment_other_events_overall
+    experimenter_experiments:
+      type: table_view
+      tables:
+        - channel: release
+          table: moz-fx-data-experiments.monitoring.experimenter_experiments_v1
 firefox_desktop:
   glean_app: true
   views:

--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1006,31 +1006,6 @@ experimentation:
       tables:
         - channel: release
           table: mozdata.telemetry.experiment_enrollment_other_events_overall
-    experiment_cumulative_search_with_ads_count:
-      type: table_view
-      tables:
-        - channel: release
-          table: mozdata.telemetry.experiment_cumulative_search_with_ads_count
-    experiment_cumulative_search_count:
-      type: table_view
-      tables:
-        - channel: release
-          table: mozdata.telemetry.experiment_cumulative_search_count
-    experiment_cumulative_ad_clicks:
-      type: table_view
-      tables:
-        - channel: release
-          table: mozdata.telemetry.experiment_cumulative_ad_clicks
-    experimenter_experiments:
-      type: table_view
-      tables:
-        - channel: release
-          table: moz-fx-data-experiments.monitoring.experimenter_experiments_v1
-    experiment_search_aggregates_live:
-      type: table_view
-      tables:
-        - channel: release
-          table: moz-fx-data-shared-prod.telemetry_derived.experiment_search_aggregates_live_v1
 firefox_desktop:
   glean_app: true
   views:


### PR DESCRIPTION
Depends on https://github.com/mozilla/looker-spoke-default/pull/989

The generated experiment search views are no longer in use and can be removed.