### PR TITLE
Change owners of Ads and Revenue Private namespaces

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -754,9 +754,9 @@ revenue_private:
   connection: bigquery-oauth
   pretty_name: Revenue Private
   owners:
+    - akommasani@mozilla.com
     - akomarzewski@mozilla.com
     - skahmann@mozilla.com
-    - xluo@mozilla.com
   spoke: looker-spoke-private
   views:
     search_revenue_levers_daily:
@@ -777,6 +777,8 @@ ads:
   pretty_name: Ads
   owners:
     - cmorales@mozilla.com
+    - cbeck@mozilla.com
+    - lvargas@mozilla.com
     - sbetancourt@mozilla.com
   spoke: looker-spoke-private
   views:


### PR DESCRIPTION
Adds Ads Data Team to owners of Ads namespace, and @alekhyamoz to owners of Revenue Private namespace