### PR TITLE
Remove legacy FxA Login Funnels

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -543,10 +543,6 @@ firefox_accounts:
       tables:
         - channel: release
           table: mozdata.firefox_accounts.fxa_log_device_command_events
-    login_funnels:
-      type: table_view
-      tables:
-        - table: moz-fx-data-shared-prod.firefox_accounts_derived.login_funnels_v1
     login_funnels_by_service:
       type: table_view
       tables:


### PR DESCRIPTION
This table has been migrated to accounts_frontend dataset, view and explore are not used.