### PR TITLE
Remove legacy FxA Registration Funnels

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -551,10 +551,6 @@ firefox_accounts:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.accounts_frontend.registration_funnels_by_service
-    registration_funnels:
-      type: table_view
-      tables:
-        - table: moz-fx-data-shared-prod.firefox_accounts_derived.registration_funnels_v1
     registration_funnels_legacy_events:
       type: table_view
       tables:


### PR DESCRIPTION
Like https://github.com/mozilla/lookml-generator/pull/1128, table has been migrated to accounts_frontend dataset, view and explore are not used.