### PR TITLE
[DENG-7019] Add legacy and glean event count explores

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1339,6 +1339,14 @@ monitoring:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.monitoring_derived.event_error_monitoring_aggregates_v1
+    legacy_desktop_event_counts:
+      type: table_view
+      tables:
+        - table: mozdata.telemetry.event_aggregates
+    glean_event_counts:
+      type: table_view
+      tables:
+        - table: mozdata.monitoring.event_counts_glean
     mlops_job_cost_per_job:
       type: table_view
       tables:
@@ -1384,6 +1392,15 @@ monitoring:
       type: ping_explore
       views:
         base_view: telemetry_missing_columns
+    legacy_desktop_event_counts:
+      type: table_explore
+      views:
+        base_view: legacy_desktop_event_counts
+    glean_event_counts:
+      type: table_explore
+      views:
+        base_view: glean_event_counts
+
 casa:
   glean_app: false
   spoke: looker-spoke-private


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-7019

Adding `monitoring_derived.event_monitoring_aggregates_v1` and `telemetry_derived.event_aggregates_v1` to looker

cc @kwindau as the owner of `telemetry_derived.event_aggregates_v1`