### PR TITLE
Add new Looker reference to table_storage in custom namespaces

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1183,6 +1183,10 @@ monitoring:
       tables:
         - table: moz-fx-data-shared-prod.monitoring.bigquery_table_storage
       type: table_view
+    bigquery_shared_prod_table_storage: 
+      tables:
+        - table: mozdata.monitoring.table_storage
+      type: table_view
     bigquery_table_storage_timeline_daily:
       tables:
         - table: moz-fx-data-shared-prod.monitoring.bigquery_table_storage_timeline_daily


### PR DESCRIPTION
This PR creates a new Looker view called `bigquery_shared_prod_table_storage` based on `mozdata.monitoring.table_storage`