### PR TITLE
take out firefox_mobile_installs from custom_namespaces.yaml

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -157,10 +157,6 @@ duet:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.fenix.marketing_attributable_metrics
-    firefox_mobile_installs:
-      type: table_view
-      tables:
-        - table: moz-fx-data-marketing-prod.adjust_derived.firefox_mobile_installs_v1
     firefox_mobile_installs_adjust_deliverables:
       type: table_view
       tables:


### PR DESCRIPTION
Remove datasource that no longer exists. Table has been deleted from `moz-fx-data-marketing-prod` due to lack of use and lack of updates since 2023