### PR TITLE
Use OAuth for `jira_service_desk`

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1846,6 +1846,7 @@ accounts_frontend:
         base_view: accounts_events
 jira_service_desk:
   pretty_name: Jira Service Desk
+  connection: bigquery-oauth
   owners:
     - rantwan@mozilla.com
   glean_app: false


### PR DESCRIPTION
This updates the `jira_service_desk` to use OAuth. This needs to be merged alongside https://github.com/mozilla/bigquery-etl/pull/6971 which adds access restrictions to the underlying datasets