### PR TITLE
Skip datagroup creation when running into permission error

### DIFF
--- a/generator/views/datagroups.py
+++ b/generator/views/datagroups.py
@@ -146,9 +146,7 @@ def _get_datagroup_from_bigquery_view(
     except DryRunError as e:
         if e.error == Errors.PERMISSION_DENIED and e.use_cloud_function:
             print(
-                "Skip datagroup creation for "
-                + f"{view_references[0][0]}.{view_references[0][1]}.{view_references[0][2]} "
-                + "due to permission error"
+                f"Skip datagroup creation for {source_table_id} due to permission error"
             )
         else:
             raise ValueError(

--- a/generator/views/datagroups.py
+++ b/generator/views/datagroups.py
@@ -144,9 +144,16 @@ def _get_datagroup_from_bigquery_view(
                 view=view,
             )
     except DryRunError as e:
-        raise ValueError(
-            f"Unable to find {source_table_id} referenced in {full_table_id}"
-        ) from e
+        if e.error == Errors.PERMISSION_DENIED and e.use_cloud_function:
+            print(
+                "Skip datagroup creation for "
+                + f"{view_references[0][0]}.{view_references[0][1]}.{view_references[0][2]} "
+                + "due to permission error"
+            )
+        else:
+            raise ValueError(
+                f"Unable to find {source_table_id} referenced in {full_table_id}"
+            ) from e
 
     return []
 


### PR DESCRIPTION
Related to https://github.com/mozilla/lookml-generator/pull/1159#issuecomment-2641335278

Datagroup creation should be skipped when underlying table is not accessible