### PR TITLE
[DENG-8141] Generate datagroups and persist explores with multiple references

### DIFF
--- a/generator/explores/client_counts_explore.py
+++ b/generator/explores/client_counts_explore.py
@@ -47,18 +47,22 @@ class ClientCountsExplore(Explore):
                         "name": "build_breakdown",
                     }
                 )
-        return [
-            {
-                "name": self.name,
-                "view_name": self.views["base_view"],
-                "description": "Client counts across dimensions and cohorts.",
-                "always_filter": {
-                    "filters": self.get_required_filters("extended_view"),
-                },
-                "queries": queries,
-                "joins": self.get_unnested_fields_joins_lookml(),
-            }
-        ]
+
+        explore_lookml = {
+            "name": self.name,
+            "view_name": self.views["base_view"],
+            "description": "Client counts across dimensions and cohorts.",
+            "always_filter": {
+                "filters": self.get_required_filters("extended_view"),
+            },
+            "queries": queries,
+            "joins": self.get_unnested_fields_joins_lookml(),
+        }
+
+        if datagroup := self.get_datagroup():
+            explore_lookml["persist_with"] = datagroup
+
+        return [explore_lookml]
 
     @staticmethod
     def from_views(views: List[View]) -> Iterator[ClientCountsExplore]:

--- a/generator/explores/events_explore.py
+++ b/generator/explores/events_explore.py
@@ -60,4 +60,8 @@ class EventsExplore(Explore):
                     "name": "all_event_counts",
                 },
             ]
+
+        if datagroup := self.get_datagroup():
+            lookml["persist_with"] = datagroup
+
         return [lookml]

--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -105,6 +105,14 @@ class Explore:
 
         Return `None` if there is no datagroup for this explore.
         """
+        if self.views_path and (self.views_path.parent / "datagroups").exists():
+            datagroups_path = self.views_path.parent / "datagroups"
+            datagroup_file = (
+                datagroups_path
+                / f'{self.views["base_view"]}_last_updated.datagroup.lkml'
+            )
+            if datagroup_file.exists():
+                return f'{self.views["base_view"]}_last_updated'
         return None
 
     def get_unnested_fields_joins_lookml(

--- a/generator/explores/funnel_analysis_explore.py
+++ b/generator/explores/funnel_analysis_explore.py
@@ -38,26 +38,32 @@ class FunnelAnalysisExplore(Explore):
         view_lookml = self.get_view_lookml("funnel_analysis")
         views = view_lookml["views"]
         n_events = len([d for d in views if d["name"].startswith("step_")])
-        defn: List[Dict[str, Any]] = [
-            {
-                "name": "funnel_analysis",
-                "description": "Count funnel completion over time. Funnels are limited to a single day.",
-                "view_label": " User-Day Funnels",
-                "always_filter": {
-                    "filters": [
-                        {"submission_date": "14 days"},
-                    ]
-                },
-                "joins": [
-                    {
-                        "name": f"step_{n}",
-                        "relationship": "many_to_one",
-                        "type": "cross",
-                    }
-                    for n in range(1, n_events + 1)
-                ],
-                "sql_always_where": "${funnel_analysis.submission_date} >= '2010-01-01'",
+
+        explore_lookml = {
+            "name": "funnel_analysis",
+            "description": "Count funnel completion over time. Funnels are limited to a single day.",
+            "view_label": " User-Day Funnels",
+            "always_filter": {
+                "filters": [
+                    {"submission_date": "14 days"},
+                ]
             },
+            "joins": [
+                {
+                    "name": f"step_{n}",
+                    "relationship": "many_to_one",
+                    "type": "cross",
+                }
+                for n in range(1, n_events + 1)
+            ],
+            "sql_always_where": "${funnel_analysis.submission_date} >= '2010-01-01'",
+        }
+
+        if datagroup := self.get_datagroup():
+            explore_lookml["persist_with"] = datagroup
+
+        defn: List[Dict[str, Any]] = [
+            explore_lookml,
             {"name": "event_names", "hidden": "yes"},
         ]
 

--- a/generator/explores/glean_ping_explore.py
+++ b/generator/explores/glean_ping_explore.py
@@ -86,6 +86,9 @@ class GleanPingExplore(PingExplore):
             "joins": joins,
         }
 
+        if datagroup := self.get_datagroup():
+            base_explore["persist_with"] = datagroup
+
         required_filters = self.get_required_filters("base_view")
         if len(required_filters) > 0:
             base_explore["always_filter"] = {"filters": required_filters}

--- a/generator/explores/growth_accounting_explore.py
+++ b/generator/explores/growth_accounting_explore.py
@@ -16,13 +16,16 @@ class GrowthAccountingExplore(Explore):
 
     def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
-        return [
-            {
-                "name": self.name,
-                "view_name": self.views["base_view"],
-                "joins": self.get_unnested_fields_joins_lookml(),
-            }
-        ]
+        explore_lookml = {
+            "name": self.name,
+            "view_name": self.views["base_view"],
+            "joins": self.get_unnested_fields_joins_lookml(),
+        }
+
+        if datagroup := self.get_datagroup():
+            explore_lookml["persist_with"] = datagroup
+
+        return [explore_lookml]
 
     @staticmethod
     def from_views(views: List[View]) -> Iterator[GrowthAccountingExplore]:

--- a/generator/explores/metric_definitions_explore.py
+++ b/generator/explores/metric_definitions_explore.py
@@ -52,6 +52,9 @@ class MetricDefinitionsExplore(Explore):
             "fields": exposed_fields,
         }
 
+        if datagroup := self.get_datagroup():
+            explore_lookml["persist_with"] = datagroup
+
         return [explore_lookml]
 
     def get_view_time_partitioning_group(self, view: str) -> Optional[str]:

--- a/generator/explores/operational_monitoring_explore.py
+++ b/generator/explores/operational_monitoring_explore.py
@@ -59,17 +59,20 @@ class OperationalMonitoringExplore(Explore):
             if "default" in info:
                 filters.append({f"{base_view_name}.{dimension}": info["default"]})
 
-        defn: List[Dict[str, Any]] = [
-            {
-                "name": self.views["base_view"],
-                "always_filter": {
-                    "filters": [
-                        {"branch": self.branches},
-                    ]
-                },
-                "hidden": "yes",
+        explore_lookml = {
+            "name": self.views["base_view"],
+            "always_filter": {
+                "filters": [
+                    {"branch": self.branches},
+                ]
             },
-        ]
+            "hidden": "yes",
+        }
+
+        if datagroup := self.get_datagroup():
+            explore_lookml["persist_with"] = datagroup
+
+        defn: List[Dict[str, Any]] = [explore_lookml]
 
         return defn
 
@@ -114,8 +117,11 @@ class OperationalMonitoringAlertingExplore(Explore):
         self,
         v1_name: Optional[str],
     ) -> List[Dict[str, Any]]:
-        defn: List[Dict[str, Any]] = [
-            {"name": self.views["base_view"], "hidden": "yes"},
-        ]
+        explore_lookml = {"name": self.views["base_view"], "hidden": "yes"}
+
+        if datagroup := self.get_datagroup():
+            explore_lookml["persist_with"] = datagroup
+
+        defn: List[Dict[str, Any]] = [explore_lookml]
 
         return defn

--- a/generator/explores/ping_explore.py
+++ b/generator/explores/ping_explore.py
@@ -16,16 +16,19 @@ class PingExplore(Explore):
 
     def _to_lookml(self, v1_name: Optional[str]) -> List[Dict[str, Any]]:
         """Generate LookML to represent this explore."""
-        return [
-            {
-                "name": self.name,
-                "view_name": self.views["base_view"],
-                "always_filter": {
-                    "filters": self.get_required_filters("base_view"),
-                },
-                "joins": self.get_unnested_fields_joins_lookml(),
-            }
-        ]
+        explore_lookml = {
+            "name": self.name,
+            "view_name": self.views["base_view"],
+            "always_filter": {
+                "filters": self.get_required_filters("base_view"),
+            },
+            "joins": self.get_unnested_fields_joins_lookml(),
+        }
+
+        if datagroup := self.get_datagroup():
+            explore_lookml["persist_with"] = datagroup
+
+        return [explore_lookml]
 
     @staticmethod
     def from_views(views: List[View]) -> Iterator[PingExplore]:

--- a/generator/explores/table_explore.py
+++ b/generator/explores/table_explore.py
@@ -45,19 +45,3 @@ class TableExplore(Explore):
     def from_dict(name: str, defn: dict, views_path: Path) -> TableExplore:
         """Get an instance of this explore from a name and dictionary definition."""
         return TableExplore(name, defn["views"], views_path)
-
-    def get_datagroup(self) -> Optional[str]:
-        """
-        Return the name of the associated datagroup.
-
-        Return `None` if there is no datagroup for this explore.
-        """
-        if self.views_path and (self.views_path.parent / "datagroups").exists():
-            datagroups_path = self.views_path.parent / "datagroups"
-            datagroup_file = (
-                datagroups_path
-                / f'{self.views["base_view"]}_last_updated.datagroup.lkml'
-            )
-            if datagroup_file.exists():
-                return f'{self.views["base_view"]}_last_updated'
-        return None

--- a/generator/views/datagroups.py
+++ b/generator/views/datagroups.py
@@ -122,7 +122,7 @@ def _get_referenced_tables(
     Recursively, resolve references of referenced views to only get table dependencies.
     """
     if [project_id, dataset_id, table_id] in seen:
-        return []
+        return [[project_id, dataset_id, table_id]]
 
     seen += [[project_id, dataset_id, table_id]]
 

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import click
 import yaml
 from jinja2 import Environment, FileSystemLoader
-from generator.namespaces import DEFAULT_GENERATED_SQL_URI
 
 GENERATOR_PATH = Path(__file__).parent.parent
 
@@ -279,28 +278,3 @@ def get_bigquery_view_reference_map(
                         ref.split(".") for ref in references["view.sql"]
                     ]
     return views
-
-
-def get_bigquery_table_references(
-    dataset_id: str,
-    table_id: str,
-    dataset_view_map: Optional[BQViewReferenceMap] = None,
-) -> List[List[str]]:
-    """
-    Return referenced tables.
-
-    Extracts referenced tables from referenced views.
-    """
-    dataset_view_references = dataset_view_map.get(dataset_id)
-    if dataset_view_references is None:
-        return []
-
-    view_references = dataset_view_references.get(table_id)
-    if view_references is None:
-        return []
-
-    return {
-        ref
-        for view_reference in view_references
-        for ref in get_bigquery_table_references(view_reference[0], view_reference[1])
-    }

--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import click
 import yaml
 from jinja2 import Environment, FileSystemLoader
+from generator.namespaces import DEFAULT_GENERATED_SQL_URI
 
 GENERATOR_PATH = Path(__file__).parent.parent
 
@@ -278,3 +279,28 @@ def get_bigquery_view_reference_map(
                         ref.split(".") for ref in references["view.sql"]
                     ]
     return views
+
+
+def get_bigquery_table_references(
+    dataset_id: str,
+    table_id: str,
+    dataset_view_map: Optional[BQViewReferenceMap] = None,
+) -> List[List[str]]:
+    """
+    Return referenced tables.
+
+    Extracts referenced tables from referenced views.
+    """
+    dataset_view_references = dataset_view_map.get(dataset_id)
+    if dataset_view_references is None:
+        return []
+
+    view_references = dataset_view_references.get(table_id)
+    if view_references is None:
+        return []
+
+    return {
+        ref
+        for view_reference in view_references
+        for ref in get_bigquery_table_references(view_reference[0], view_reference[1])
+    }

--- a/tests/test_datagroups.py
+++ b/tests/test_datagroups.py
@@ -56,26 +56,24 @@ class MockDryRunDatagroups(MockDryRun):
 def test_generates_datagroups(reference_map_mock, runner):
     table_1_expected = (
         FILE_HEADER
-        + """datagroup: test_table_last_updated {
-  label: "Test Table Last Updated"
+        + """datagroup: table_1_last_updated {
+  label: "table_1 Last Updated"
   sql_trigger: SELECT MAX(storage_last_modified_time)
-    FROM `mozdata`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
-    WHERE table_schema = 'analysis'
-    AND table_name = 'test_table' ;;
-  description: "Updates when mozdata.analysis.test_table is modified."
+    FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
+    WHERE (table_schema = 'analysis' AND table_name = 'test_table') ;;
+  description: "Updates for table_1 when referenced tables are modified."
   max_cache_age: "24 hours"
 }"""
     )
 
     table_2_expected = (
         FILE_HEADER
-        + """datagroup: test_table_2_last_updated {
-  label: "Test Table 2 Last Updated"
+        + """datagroup: table_2_last_updated {
+  label: "table_2 Last Updated"
   sql_trigger: SELECT MAX(storage_last_modified_time)
-    FROM `mozdata`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
-    WHERE table_schema = 'analysis'
-    AND table_name = 'test_table_2' ;;
-  description: "Updates when mozdata.analysis.test_table_2 is modified."
+    FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
+    WHERE (table_schema = 'analysis' AND table_name = 'test_table_2') ;;
+  description: "Updates for table_2 when referenced tables are modified."
   max_cache_age: "24 hours"
 }"""
     )
@@ -114,20 +112,20 @@ def test_generates_datagroups(reference_map_mock, runner):
 
         assert Path(namespace_dir / "datagroups").exists()
         assert Path(
-            namespace_dir / "datagroups/test_table_last_updated.datagroup.lkml"
+            namespace_dir / "datagroups/table_1_last_updated.datagroup.lkml"
         ).exists()
         assert (
             Path(
-                namespace_dir / "datagroups/test_table_last_updated.datagroup.lkml"
+                namespace_dir / "datagroups/table_1_last_updated.datagroup.lkml"
             ).read_text()
             == table_1_expected
         )
         assert Path(
-            namespace_dir / "datagroups/test_table_2_last_updated.datagroup.lkml"
+            namespace_dir / "datagroups/table_2_last_updated.datagroup.lkml"
         ).exists()
         assert (
             Path(
-                namespace_dir / "datagroups/test_table_2_last_updated.datagroup.lkml"
+                namespace_dir / "datagroups/table_2_last_updated.datagroup.lkml"
             ).read_text()
             == table_2_expected
         )
@@ -144,26 +142,12 @@ def test_generates_datagroups(reference_map_mock, runner):
 def test_generates_datagroups_with_tables_and_views(runner):
     table_1_expected = (
         FILE_HEADER
-        + """datagroup: test_table_last_updated {
-  label: "Test Table Last Updated"
-  sql_trigger: SELECT MAX(storage_last_modified_time)
-    FROM `mozdata`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
-    WHERE table_schema = 'analysis'
-    AND table_name = 'test_table' ;;
-  description: "Updates when mozdata.analysis.test_table is modified."
-  max_cache_age: "24 hours"
-}"""
-    )
-
-    source_table_expected = (
-        FILE_HEADER
-        + """datagroup: view_1_source_last_updated {
-  label: "View Source Table Last Updated"
+        + """datagroup: table_1_last_updated {
+  label: "table_1 Last Updated"
   sql_trigger: SELECT MAX(storage_last_modified_time)
     FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
-    WHERE table_schema = 'analysis'
-    AND table_name = 'view_1_source' ;;
-  description: "Updates when moz-fx-data-shared-prod.analysis.view_1_source is modified."
+    WHERE (table_schema = 'analysis' AND table_name = 'test_table') ;;
+  description: "Updates for table_1 when referenced tables are modified."
   max_cache_age: "24 hours"
 }"""
     )
@@ -201,23 +185,15 @@ def test_generates_datagroups_with_tables_and_views(runner):
             )
 
         assert Path("looker-hub/test_namespace/datagroups").exists()
+        assert len(list((namespace_dir / "datagroups").iterdir())) == 1
         assert Path(
-            namespace_dir / "datagroups/test_table_last_updated.datagroup.lkml"
+            namespace_dir / "datagroups/table_1_last_updated.datagroup.lkml"
         ).exists()
         assert (
             Path(
-                namespace_dir / "datagroups/test_table_last_updated.datagroup.lkml"
+                namespace_dir / "datagroups/table_1_last_updated.datagroup.lkml"
             ).read_text()
             == table_1_expected
-        )
-        assert Path(
-            namespace_dir / "datagroups/view_1_source_last_updated.datagroup.lkml"
-        ).exists()
-        assert (
-            Path(
-                namespace_dir / "datagroups/view_1_source_last_updated.datagroup.lkml"
-            ).read_text()
-            == source_table_expected
         )
 
 
@@ -256,13 +232,12 @@ def test_only_generates_one_datagroup_for_references_to_same_table(
 ):
     expected = (
         FILE_HEADER
-        + """datagroup: source_table_last_updated {
-  label: "Source Table Last Updated"
+        + """datagroup: test_table_last_updated {
+  label: "test_table Last Updated"
   sql_trigger: SELECT MAX(storage_last_modified_time)
     FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
-    WHERE table_schema = 'analysis'
-    AND table_name = 'source_table' ;;
-  description: "Updates when moz-fx-data-shared-prod.analysis.source_table is modified."
+    WHERE (table_schema = 'analysis' AND table_name = 'source_table') ;;
+  description: "Updates for test_table when referenced tables are modified."
   max_cache_age: "24 hours"
 }"""
     )
@@ -315,12 +290,10 @@ def test_only_generates_one_datagroup_for_references_to_same_table(
             )
 
         assert Path(namespace_dir / "datagroups").exists()
-        assert len(list((namespace_dir / "datagroups").iterdir())) == 2
+        assert len(list((namespace_dir / "datagroups").iterdir())) == 1
         assert (
             Path(
-                namespace_dir
-                / "datagroups"
-                / "source_table_last_updated.datagroup.lkml"
+                namespace_dir / "datagroups" / "test_table_last_updated.datagroup.lkml"
             ).read_text()
             == expected
         )

--- a/tests/test_datagroups.py
+++ b/tests/test_datagroups.py
@@ -59,8 +59,13 @@ def test_generates_datagroups(reference_map_mock, runner):
         + """datagroup: table_1_last_updated {
   label: "table_1 Last Updated"
   sql_trigger: SELECT MAX(storage_last_modified_time)
-    FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
-    WHERE (table_schema = 'analysis' AND table_name = 'test_table') ;;
+    FROM (
+        
+    SELECT MAX(storage_last_modified_time) AS storage_last_modified_time
+    FROM `mozdata`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
+    WHERE (table_schema = 'analysis' AND table_name = 'test_table')
+
+    ) ;;
   description: "Updates for table_1 when referenced tables are modified."
   max_cache_age: "24 hours"
 }"""
@@ -71,8 +76,13 @@ def test_generates_datagroups(reference_map_mock, runner):
         + """datagroup: table_2_last_updated {
   label: "table_2 Last Updated"
   sql_trigger: SELECT MAX(storage_last_modified_time)
-    FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
-    WHERE (table_schema = 'analysis' AND table_name = 'test_table_2') ;;
+    FROM (
+        
+    SELECT MAX(storage_last_modified_time) AS storage_last_modified_time
+    FROM `mozdata`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
+    WHERE (table_schema = 'analysis' AND table_name = 'test_table_2')
+
+    ) ;;
   description: "Updates for table_2 when referenced tables are modified."
   max_cache_age: "24 hours"
 }"""
@@ -145,8 +155,13 @@ def test_generates_datagroups_with_tables_and_views(runner):
         + """datagroup: table_1_last_updated {
   label: "table_1 Last Updated"
   sql_trigger: SELECT MAX(storage_last_modified_time)
-    FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
-    WHERE (table_schema = 'analysis' AND table_name = 'test_table') ;;
+    FROM (
+        
+    SELECT MAX(storage_last_modified_time) AS storage_last_modified_time
+    FROM `mozdata`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
+    WHERE (table_schema = 'analysis' AND table_name = 'test_table')
+
+    ) ;;
   description: "Updates for table_1 when referenced tables are modified."
   max_cache_age: "24 hours"
 }"""
@@ -157,8 +172,13 @@ def test_generates_datagroups_with_tables_and_views(runner):
         + """datagroup: test_view_last_updated {
   label: "test_view Last Updated"
   sql_trigger: SELECT MAX(storage_last_modified_time)
+    FROM (
+        
+    SELECT MAX(storage_last_modified_time) AS storage_last_modified_time
     FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
-    WHERE (table_schema = 'analysis' AND table_name = 'view_1_source') ;;
+    WHERE (table_schema = 'analysis' AND table_name = 'view_1_source')
+
+    ) ;;
   description: "Updates for test_view when referenced tables are modified."
   max_cache_age: "24 hours"
 }"""
@@ -256,8 +276,13 @@ def test_only_generates_one_datagroup_for_references_to_same_table(
         + """datagroup: test_table_last_updated {
   label: "test_table Last Updated"
   sql_trigger: SELECT MAX(storage_last_modified_time)
+    FROM (
+        
+    SELECT MAX(storage_last_modified_time) AS storage_last_modified_time
     FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
-    WHERE (table_schema = 'analysis' AND table_name = 'source_table') ;;
+    WHERE (table_schema = 'analysis' AND table_name = 'source_table')
+
+    ) ;;
   description: "Updates for test_table when referenced tables are modified."
   max_cache_age: "24 hours"
 }"""
@@ -268,8 +293,13 @@ def test_only_generates_one_datagroup_for_references_to_same_table(
         + """datagroup: view_1_last_updated {
   label: "view_1 Last Updated"
   sql_trigger: SELECT MAX(storage_last_modified_time)
-    FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
-    WHERE (table_schema = 'analysis' AND table_name = 'view_1') ;;
+    FROM (
+        
+    SELECT MAX(storage_last_modified_time) AS storage_last_modified_time
+    FROM `mozdata`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
+    WHERE (table_schema = 'analysis' AND table_name = 'view_1')
+
+    ) ;;
   description: "Updates for view_1 when referenced tables are modified."
   max_cache_age: "24 hours"
 }"""


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-8141
Closes https://github.com/mozilla/lookml-generator/issues/1089

This PR updates the LookML-Generator to:
* Include datagroups for explores referencing BigQuery views querying multiple tables. This ensures efficient cache validation
*  Expand the explore generation logic to include all types of explores, beyond the currently supported table explores

The generation logic changes slightly. Instead of creating a datagroup per BigQuery table, now a datagroup per view is being generated.

Validated here: https://github.com/mozilla/looker-hub/compare/test-datagroup-generation?expand=1

Needs to be merged with: https://github.com/mozilla/looker-spoke-default/pull/1043
Some updates to datagroups were needed as they are now generated for Looker views (and not BQ tables anymore). spoke-private didn't require any updates

**Benefits:**
* Decreases costs by minimizing the volume of direct data processing
* Improves dashboard performance through more effective data caching for more types of explores