### PR TITLE
Uppercase some common initialisms in titles

### DIFF
--- a/generator/views/lookml_utils.py
+++ b/generator/views/lookml_utils.py
@@ -43,6 +43,42 @@ MAP_LAYER_NAMES = {
 
 DEFAULT_MAX_SUGGEST_PERSIST_FOR = "24 hours"
 
+UPPERCASE_INITIALISMS_PATTERN = re.compile(
+    (
+        r"\b("
+        + "|".join(
+            [
+                "CPU",
+                "DB",
+                "DNS",
+                "DNT",
+                "DOM",
+                "GC",
+                "GPU",
+                "HTTP",
+                "ID",
+                "IO",
+                "IP",
+                "ISP",
+                "JWE",
+                "LB",
+                "OS",
+                "SDK",
+                "SERP",
+                "SSL",
+                "TLS",
+                "UI",
+                "URI",
+                "URL",
+                "UTM",
+                "UUID",
+            ]
+        )
+        + r")\b"
+    ),
+    re.IGNORECASE,
+)
+
 
 def _get_dimension(
     path: Tuple[str, ...], field_type: str, mode: str, description: Optional[str]
@@ -250,8 +286,10 @@ def render_template(filename, template_folder, **kwargs) -> str:
 
 
 def slug_to_title(slug):
-    """Convert a slug to title case."""
-    return slug.replace("_", " ").title()
+    """Convert a slug to title case, with some common initialisms uppercased."""
+    return UPPERCASE_INITIALISMS_PATTERN.sub(
+        lambda match: match.group(0).upper(), slug.replace("_", " ").title()
+    )
 
 
 # Map from view to qualified references {dataset: {view: [[project, dataset, table],]}}

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -1236,17 +1236,17 @@ def test_lookml_actual_metric_definitions_view(
                             ],
                         },
                         {
-                            "group_item_label": "Jwe",
+                            "group_item_label": "JWE",
                             "group_label": "Test",
                             "name": "metrics__jwe2__test_jwe",
-                            "label": "Test Jwe",
+                            "label": "Test JWE",
                             "sql": "${TABLE}.metrics.jwe2.test_jwe",
                             "type": "string",
                             "hidden": "no",
                             "links": [
                                 {
                                     "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
-                                    "label": "Glean Dictionary reference for Test Jwe",
+                                    "label": "Glean Dictionary reference for Test JWE",
                                     "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/test_jwe",  # noqa: E501
                                 }
                             ],
@@ -1364,33 +1364,33 @@ def test_lookml_actual_metric_definitions_view(
                             ],
                         },
                         {
-                            "group_item_label": "Uuid",
+                            "group_item_label": "UUID",
                             "group_label": "Test",
                             "name": "metrics__uuid__test_uuid",
-                            "label": "Test Uuid",
+                            "label": "Test UUID",
                             "sql": "${TABLE}.metrics.uuid.test_uuid",
                             "type": "string",
                             "hidden": "no",
                             "links": [
                                 {
                                     "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
-                                    "label": "Glean Dictionary reference for Test Uuid",
+                                    "label": "Glean Dictionary reference for Test UUID",
                                     "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/test_uuid",  # noqa: E501
                                 }
                             ],
                         },
                         {
-                            "group_item_label": "Url",
+                            "group_item_label": "URL",
                             "group_label": "Test",
                             "name": "metrics__url2__test_url",
-                            "label": "Test Url",
+                            "label": "Test URL",
                             "sql": "${TABLE}.metrics.url2.test_url",
                             "type": "string",
                             "hidden": "no",
                             "links": [
                                 {
                                     "icon_url": "https://dictionary.telemetry.mozilla.org/favicon.png",  # noqa: E501
-                                    "label": "Glean Dictionary reference for Test Url",
+                                    "label": "Glean Dictionary reference for Test URL",
                                     "url": "https://dictionary.telemetry.mozilla.org/apps/glean-app/metrics/test_url",  # noqa: E501
                                 }
                             ],

--- a/tests/test_operational_monitoring.py
+++ b/tests/test_operational_monitoring.py
@@ -232,8 +232,8 @@ def test_dashboard_lookml(operational_monitoring_dashboard):
   preferred_viewer: dashboards-next
 
   elements:
-  - title: Gc Ms
-    name: Gc Ms_mean
+  - title: GC Ms
+    name: GC Ms_mean
     note_state: expanded
     note_display: above
     note_text: Mean
@@ -263,13 +263,13 @@ def test_dashboard_lookml(operational_monitoring_dashboard):
     listen:
       Date: fission.build_id
       Cores Count: fission.cores_count
-      Os: fission.os
+      OS: fission.os
 
     enabled: "#3FE1B0"
     disabled: "#0060E0"
     defaults_version: 0
-  - title: Gc Ms Content
-    name: Gc Ms Content_percentile
+  - title: GC Ms Content
+    name: GC Ms Content_percentile
     note_state: expanded
     note_display: above
     note_text: Percentile
@@ -302,7 +302,7 @@ def test_dashboard_lookml(operational_monitoring_dashboard):
       Date: fission.build_id
       Percentile: fission.parameter
       Cores Count: fission.cores_count
-      Os: fission.os
+      OS: fission.os
 
     enabled: "#3FE1B0"
     disabled: "#0060E0"
@@ -351,8 +351,8 @@ def test_dashboard_lookml(operational_monitoring_dashboard):
 
 
 
-  - title: Os
-    name: Os
+  - title: OS
+    name: OS
     type: string_filter
     default_value: 'Windows'
     allow_multiple_values: false
@@ -416,8 +416,8 @@ def test_dashboard_lookml_group_by_dimension(
   preferred_viewer: dashboards-next
 
   elements:
-  - title: Gc Ms - By os
-    name: Gc Ms - By os_mean
+  - title: GC Ms - By os
+    name: GC Ms - By os_mean
     note_state: expanded
     note_display: above
     note_text: Mean
@@ -447,13 +447,13 @@ def test_dashboard_lookml_group_by_dimension(
     listen:
       Date: fission.build_id
       Cores Count: fission.cores_count
-      Os: fission.os
+      OS: fission.os
 
     enabled: "#3FE1B0"
     disabled: "#0060E0"
     defaults_version: 0
-  - title: Gc Ms Content - By os
-    name: Gc Ms Content - By os_percentile
+  - title: GC Ms Content - By os
+    name: GC Ms Content - By os_percentile
     note_state: expanded
     note_display: above
     note_text: Percentile
@@ -486,7 +486,7 @@ def test_dashboard_lookml_group_by_dimension(
       Date: fission.build_id
       Percentile: fission.parameter
       Cores Count: fission.cores_count
-      Os: fission.os
+      OS: fission.os
 
     enabled: "#3FE1B0"
     disabled: "#0060E0"
@@ -535,8 +535,8 @@ def test_dashboard_lookml_group_by_dimension(
 
 
 
-  - title: Os
-    name: Os
+  - title: OS
+    name: OS
     type: string_filter
     default_value: 'Linux,Windows'
     allow_multiple_values: true


### PR DESCRIPTION
For a nicer user experience in Looker (e.g. "OS" instead of "Os").