### PR TITLE
Update `pre-commit` dependencies to match `requirements.txt`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.3.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.1.1
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/isort
@@ -18,18 +18,18 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         exclude: (.*/)?test_.*\.py
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v1.5.1
     hooks:
       - id: mypy
         additional_dependencies:
           - types-PyYAML
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.3
+    rev: v1.37.0
     hooks:
       - id: yamllint
         args: [-c, .yamllint.yaml, .]


### PR DESCRIPTION
Dependabot doesn't update the `pre-commit` dependencies, so over time they become more and more out of sync with `requirements.txt`.