### PR TITLE
feat(DENG-8082): Add new view and explore for HNT content reporting

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1134,6 +1134,10 @@ firefox_desktop:
       type: table_view
       tables:
         - table: mozdata.analysis.fenix_distribution_deal_v1
+    newtab_items_daily:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.firefox_desktop_derived.newtab_items_daily_v1
   explores:
     client_counts:
       type: client_counts_explore
@@ -1174,6 +1178,10 @@ firefox_desktop:
       type: table_explore
       views:
         base_view: fenix_distribution_deal
+    newtab_items_daily:
+      type: table_explore
+      views:
+        base_view: newtab_items_daily
 monitoring:
   glean_app: false
   owners:


### PR DESCRIPTION
This is to define a Looker view and explore for a new derived table for HNT content reporting introduced in https://github.com/mozilla/bigquery-etl/pull/7257.

We will use this for [DENG-8082](https://mozilla-hub.atlassian.net/browse/DENG-8082).

