### PR TITLE
Fix metric definition date field SQL references

### DIFF
--- a/generator/views/metric_definitions_view.py
+++ b/generator/views/metric_definitions_view.py
@@ -164,12 +164,26 @@ class MetricDefinitionsView(View):
                     and dimension["name"] not in seen_dimensions
                     and "hidden" not in dimension
                 ):
+                    sql = (
+                        f"{data_source}.{dimension['name'].replace('__', '.')} AS"
+                        + f" {data_source}_{dimension['name']},\n"
+                    )
+                    # date/time/timestamp suffixes are removed when generating lookml dimensions, however we
+                    # need the original field name for the derived view SQL
+                    if dimension["type"] == "time" and not dimension["sql"].endswith(
+                        dimension["name"]
+                    ):
+                        suffix = dimension["sql"].split(dimension["name"])[-1]
+                        sql = (
+                            f"{data_source}.{(dimension['name']+suffix).replace('__', '.')} AS"
+                            + f" {data_source}_{dimension['name']},\n"
+                        )
+
                     base_view_fields.append(
                         {
                             "name": f"{data_source}_{dimension['name']}",
                             "select_sql": f"{data_source}_{dimension['name']},\n",
-                            "sql": f"{data_source}.{dimension['name'].replace('__', '.')} AS"
-                            + f" {data_source}_{dimension['name']},\n",
+                            "sql": sql,
                         }
                     )
                     seen_dimensions.add(dimension["name"])


### PR DESCRIPTION
Lookml-generator removes `_date`/`_time`/`_timestamp` suffixes when generating lookml dimensions, however we
need the original field name for the derived view SQL in the metric definition views. Currently, by removing the suffixes the incorrect names are used to select these fields from the source tables

See https://mozilla.slack.com/archives/C4D5ZA91B/p1746032441161499?thread_ts=1745336833.230079&cid=C4D5ZA91B