### PR TITLE
Fix metric definition date field names that have `__`

### DIFF
--- a/generator/views/metric_definitions_view.py
+++ b/generator/views/metric_definitions_view.py
@@ -173,7 +173,9 @@ class MetricDefinitionsView(View):
                     if dimension["type"] == "time" and not dimension["sql"].endswith(
                         dimension["name"]
                     ):
-                        suffix = dimension["sql"].split(dimension["name"])[-1]
+                        suffix = dimension["sql"].split(
+                            dimension["name"].replace("__", ".")
+                        )[-1]
                         sql = (
                             f"{data_source}.{(dimension['name']+suffix).replace('__', '.')} AS"
                             + f" {data_source}_{dimension['name']},\n"


### PR DESCRIPTION
Fixes failing lookml validation: https://workflow.telemetry.mozilla.org/dags/looker/grid?search=looker&dag_run_id=manual__2025-05-01T12%3A57%3A37.811735%2B00%3A00&task_id=validate_lookml_spoke_default_spectacles&tab=logs