### PR TITLE
feat(DENG-8396): Add new Glean AUA view to Looker

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -39,6 +39,10 @@ combined_browser_metrics:
       type: table_view
       tables:
         - table: mozilla-public-data.telemetry_derived.fenix_and_firefox_use_counters
+    glean_active_users_aggregates:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.glean_telemetry.active_users_aggregates
 review_checker_desktop:
   glean_app: false
   owners:


### PR DESCRIPTION
This adds a new view to Looker:
- Looker name:     `glean_active_users_aggregates`
- Source table: `moz-fx-data-shared-prod.glean_telemetry.active_users_aggregates`