### PR TITLE
[DENG-8480] Use CODEOWNERS for tagging reviewers for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,4 @@ updates:
     directory: /
     schedule:
       interval: daily
-    reviewers:
-      - mozilla/data-looker
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Dependency updates (via dependabot)
+requirements.in @mozilla/data-looker
+requirements.txt @mozilla/data-looker


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-8480

Dependabot reviewers configuration is being removed, and instead they are recommending to rely on CODEOWNERS files to assign reviewers
