### PR TITLE
[DENG-8623] Mechanism to exclude generated LookML content

### DIFF
--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -96,7 +96,11 @@ class Explore:
     def get_view_lookml(self, view: str) -> dict:
         """Get the LookML for a view."""
         if self.views_path is not None:
-            return lkml.load((self.views_path / f"{view}.view.lkml").read_text())
+            try:
+                return lkml.load((self.views_path / f"{view}.view.lkml").read_text())
+            except Exception as e:
+                print(e)
+                print(view)
         raise Exception("Missing view path for get_view_lookml")
 
     def get_datagroup(self) -> Optional[str]:

--- a/generator/explores/explore.py
+++ b/generator/explores/explore.py
@@ -96,11 +96,8 @@ class Explore:
     def get_view_lookml(self, view: str) -> dict:
         """Get the LookML for a view."""
         if self.views_path is not None:
-            try:
-                return lkml.load((self.views_path / f"{view}.view.lkml").read_text())
-            except Exception as e:
-                print(e)
-                print(view)
+            return lkml.load((self.views_path / f"{view}.view.lkml").read_text())
+
         raise Exception("Missing view path for get_view_lookml")
 
     def get_datagroup(self) -> Optional[str]:

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -415,7 +415,7 @@ def namespaces(
 def _filter_disallowed(namespaces, disallowlist):
     """Filter models, explores and views from the generated namespaces config, based on the disallowlist."""
 
-    def match_any(patterns, name):
+    def match_any(name, patterns):
         return any(fnmatch.fnmatch(name, p) for p in patterns)
 
     # transform namespace disallowlist to a dict
@@ -443,7 +443,7 @@ def _filter_disallowed(namespaces, disallowlist):
                 for artifact_type, disallowed_artifact_names in sub_filters.items():
                     if artifact_type in entry:
                         for key in list(entry[artifact_type]):
-                            if match_any(disallowed_artifact_names, key):
+                            if match_any(key, disallowed_artifact_names):
                                 del entry[artifact_type][key]
 
     return filtered_namespaces

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -190,7 +190,7 @@ def _get_glean_apps(
 
     get_app_name = itemgetter("app_name")
     with urllib.request.urlopen(app_listings_uri) as f:
-        # groupby requires input be sorted by key to produce one filtered_namespaces per key
+        # groupby requires input be sorted by key to produce one result per key
         app_listings = sorted(json.loads(f.read()), key=get_app_name)
 
     apps = []
@@ -413,6 +413,8 @@ def namespaces(
 
 
 def _filter_disallowed(namespaces, disallowlist):
+    """Filter models, explores and views from the generated namespaces config, based on the disallowlist."""
+
     def match_any(patterns, name):
         return any(fnmatch.fnmatch(name, p) for p in patterns)
 

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -359,7 +359,7 @@ def namespaces(
     use_cloud_function,
 ):
     """Generate namespaces.yaml."""
-    # warnings.filterwarnings("ignore", module="google.auth._default")
+    warnings.filterwarnings("ignore", module="google.auth._default")
     glean_apps = _get_glean_apps(app_listings_uri)
     db_views = lookml_utils.get_bigquery_view_reference_map(generated_sql_uri)
 

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -402,7 +402,7 @@ def namespaces(
     _merge_namespaces(namespaces, _get_metric_hub_namespaces(namespaces))
 
     updated_namespaces = _filter_disallowed(namespaces, disallowlist)
-    for namespace, _ in updated_namespaces.items():
+    for namespace in updated_namespaces:
         if namespace not in ignore:
             if "spoke" not in updated_namespaces[namespace]:
                 updated_namespaces[namespace]["spoke"] = DEFAULT_SPOKE

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -419,7 +419,7 @@ def _filter_disallowed(namespaces, disallowlist):
         return any(fnmatch.fnmatch(name, p) for p in patterns)
 
     # transform namespace disallowlist to a dict
-    disallowed_namespaces = yaml.safe_load(disallowlist.read()) or {}
+    disallowed_namespaces = yaml.safe_load(disallowlist.read()) or []
     disallowed_namespaces_dict = {}
     for ns in [
         {namespace: {}} if isinstance(namespace, str) else namespace

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -29,3 +29,8 @@
 - firefox_desktop_background_tasks
 - hubs
 - gleanjs_docs
+- firefox_ios:
+    views:
+      - addresses_sync
+    explores:
+      - addresses_sync

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -80,6 +80,11 @@ def custom_namespaces(tmp_path):
                   tables:
                   - table: mozdata.custom.partitioned_table
                     time_partitioning_field: timestamp
+                nested_disallowed:
+                  type: ping_view
+                  tables:
+                  - channel: release
+                    table: mozdata.custom.disallowed
             disallowed:
               pretty_name: Disallowed
               owners:
@@ -134,6 +139,9 @@ def namespace_disallowlist(tmp_path):
             ---
             - disallowed
             - disallowed_*
+            - custom:
+                views:
+                  - nested_disallowed
             """
         )
     )


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-8623

Based on proposal: https://docs.google.com/document/d/1CJq_avwso-fK7F4H3483brw8yAYFA0VQbgrfOA5ZY3s/edit?tab=t.0

Our Looker instance has a lot of generated LookML, some of which is very rarely or never being looked at. lookml-generator automatically generates a set of views and explores for every Glean application. The amount of LookML content is impacting the overall performance of our Looker instance. 

This extends the existing namespaces-disallowlist.yaml to exclude views and explores from being generated.
