### PR TITLE
feat: add glean-only experimentation views

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -981,26 +981,51 @@ experimentation:
       tables:
         - channel: release
           table: mozdata.telemetry.experiment_enrollment_daily_active_population
+    experiment_enrollment_daily_active_population_v2:
+      type: table_view
+      tables:
+        - channel: release
+          table: mozdata.telemetry.experiment_enrollment_daily_active_population_v2
     experiment_enrollment_cumulative_population_estimate:
       type: table_view
       tables:
         - channel: release
           table: mozdata.telemetry.experiment_enrollment_cumulative_population_estimate
+    experiment_enrollment_cumulative_population_estimate_v2:
+      type: table_view
+      tables:
+        - channel: release
+          table: mozdata.telemetry.experiment_enrollment_cumulative_population_estimate_v2
     experiment_enrollment_overall:
       type: table_view
       tables:
         - channel: release
           table: mozdata.telemetry.experiment_enrollment_overall
+    experiment_enrollment_overall_v2:
+      type: table_view
+      tables:
+        - channel: release
+          table: mozdata.telemetry.experiment_enrollment_overall_v2
     experiment_unenrollment_overall:
       type: table_view
       tables:
         - channel: release
           table: mozdata.telemetry.experiment_unenrollment_overall
+    experiment_unenrollment_overall_v2:
+      type: table_view
+      tables:
+        - channel: release
+          table: mozdata.telemetry.experiment_unenrollment_overall_v2
     experiment_enrollment_other_events_overall:
       type: table_view
       tables:
         - channel: release
           table: mozdata.telemetry.experiment_enrollment_other_events_overall
+    experiment_enrollment_other_events_overall_v2:
+      type: table_view
+      tables:
+        - channel: release
+          table: mozdata.telemetry.experiment_enrollment_other_events_overall_v2
     experiment_cumulative_search_with_ads_count:
       type: table_view
       tables:


### PR DESCRIPTION
Adds views needed to create glean-only dashboard for experiment enrollments monitoring.