### PR TITLE
Exclude unused models and pings

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -41,3 +41,33 @@
 - firefox_crashreporter
 - firefox_desktop_background_defaultagent
 - thunderbird_android
+- "*": # exclude these pings/views/explores from all namespaces
+    views:
+      - activation
+      - baseline_clients_daily
+      - baseline_clients_first_seen
+      - bounce_tracking_protection
+      - captcha_detection
+      - cookie_banner_report_site
+      - dau_reporting
+      - event_names
+      - feature_usage
+      - fog_validation
+      - hang_report
+      - pageload
+      - usage_deletion_request
+    explores:
+      - activation
+      - baseline_clients_daily
+      - baseline_clients_first_seen
+      - baseline_clients_last_seen
+      - bounce_tracking_protection
+      - captcha_detection
+      - cookie_banner_report_site
+      - dau_reporting
+      - event_names
+      - feature_usage
+      - fog_validation
+      - hang_report
+      - pageload
+      - usage_deletion_request

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -34,3 +34,10 @@
       - addresses_sync
     explores:
       - addresses_sync
+- fakespot
+- review_checker_desktop
+- review_checker
+- debug_ping_view
+- firefox_crashreporter
+- firefox_desktop_background_defaultagent
+- thunderbird_android


### PR DESCRIPTION
Depends on https://github.com/mozilla/looker-spoke-default/pull/1086

These are some of the models and pings that have not been used in at least 90 days or longer based on https://mozilla.cloud.looker.com/dashboards/2375

I already checked that no dashboard depends on any of these artifacts (and if so archived them).

See generated LookML: https://github.com/mozilla/looker-hub/compare/ascholtz-remove-unused-3?expand=1
Manually tested and validated in Looker