### PR TITLE
Remove desktop_search_alert_latest_daily

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -254,10 +254,6 @@ search:
       type: ping_view
       tables:
         - table: mozdata.analysis.desktop_search_alert_records
-    desktop_search_alert_latest_daily:
-      type: table_view
-      tables:
-        - table: mozdata.analysis.desktop_search_alert_latest_daily
   explores:
     desktop_search_counts:
       type: ping_explore


### PR DESCRIPTION
`mozdata.analysis.desktop_search_alert_latest_daily` got removed. It was only used on a dashboard that hasn't been in use for a while and got archived.
Depends on https://github.com/mozilla/looker-spoke-default/pull/1100