### PR TITLE
Remove desktop_search_alert_records

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -250,10 +250,6 @@ search:
       type: table_view
       tables:
         - table: mozdata.search.desktop_mobile_search_clients_monthly
-    desktop_search_alert_records:
-      type: ping_view
-      tables:
-        - table: mozdata.analysis.desktop_search_alert_records
   explores:
     desktop_search_counts:
       type: ping_explore
@@ -263,10 +259,6 @@ search:
       type: ping_explore
       views:
         base_view: mobile_search_clients_engines_sources_daily
-    desktop_search_alert_records:
-      type: ping_explore
-      views:
-        base_view: desktop_search_alert_records
 contextual_services_private:
   glean_app: false
   connection: bigquery-oauth


### PR DESCRIPTION
The underlying `mozdata.analysis.desktop_search_alert_records` got removed. There are no dashboards referencing this explore, so we can just delete it.