### PR TITLE
Add cohort_daily_churn to looker

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -35,6 +35,10 @@ combined_browser_metrics:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.telemetry.cohort_weekly_statistics
+    cohort_churn:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.telemetry.cohort_daily_churn
     fenix_and_firefox_use_counters:
       type: table_view
       tables:


### PR DESCRIPTION
This PR adds a new view called `cohort_churn` in the `combined_browser_metrics` namespace that points at the view: 
- `moz-fx-data-shared-prod.telemetry.cohort_daily_churn`