### PR TITLE
Remove table that no longer exists from Looker

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1101,10 +1101,6 @@ firefox_desktop:
       type: table_view
       tables:
         - table: mozdata.firefox_desktop.new_profiles_aggregates
-    fenix_distribution_deal:
-      type: table_view
-      tables:
-        - table: mozdata.analysis.fenix_distribution_deal_v1
     newtab_items_daily:
       type: table_view
       tables:


### PR DESCRIPTION
There was a looker view called "fenix_distribution_deal" pointing to the table `mozdata.analysis.fenix_distribution_deal_v1`, but this table no longer exists.  This is causing errors in the Looker DAG. 