### PR TITLE
feat(DENG-9322) Remove unused models and explores for fenix and monitoring

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1357,15 +1357,7 @@ monitoring:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.monitoring.looker_usage_models
-    looker_usage_unused_explores:
-      type: table_view
-      tables:
-        - table: moz-fx-data-shared-prod.monitoring.looker_usage_unused_explores
   explores:
-    column_size:
-      type: ping_explore
-      views:
-        base_view: column_size
     payload_bytes_error_all:
       type: ping_explore
       views:
@@ -1410,10 +1402,6 @@ monitoring:
       type: table_explore
       views:
         base_view: looker_usage_models
-    looker_usage_unused_explores:
-      type: table_explore
-      views:
-        base_view: looker_usage_unused_explores
 
 reference:
   glean_app: false

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -36,6 +36,8 @@
 - firefox_crashreporter
 - firefox_desktop_background_defaultagent
 - thunderbird_android
+- firefox_desktop_background_update
+- thunderbird_desktop
 - fenix:
     views:
       - installation
@@ -75,6 +77,14 @@
       - temp_sync
       - temp_tabs_sync
       - topsites_impression
+- monitor_frontend:
+    views:
+      - deletion_request
+      - deletion_request_table
+      - events_stream_table
+    explores:
+      - deletion_request
+      - events_stream_table
 - "*": # exclude these pings/views/explores from all namespaces
     views:
       - addresses_sync

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -40,12 +40,21 @@
 - thunderbird_desktop
 - fenix:
     views:
+      - bookmarks_sync
+      - bookmarks_sync_table
+      - broken_site_report
+      - broken_site_report_table
       - installation
       - installation_table
+      - migration
+      - migration_table
       - topsites_impression
       - topsites_impression_table
     explores:
+      - bookmarks_sync
+      - broken_site_report
       - installation
+      - migration
       - topsites_impression
 - firefox_ios:
     views:


### PR DESCRIPTION
The firefox_desktop_background_update and thunderbird_desktop are not in use and can be removed. There are some fenix explores and monitoring explores which are also not in use and removed as part of this pr

Depends on https://github.com/mozilla/looker-spoke-default/pull/1138