### PR TITLE
Generate views for SubPlat exchange rates and VAT rates

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1711,6 +1711,14 @@ subscription_platform:
       type: table_view
       tables:
         - table: mozdata.subscription_platform.stripe_products
+    exchange_rates:
+      type: table_view
+      tables:
+        - table: mozdata.subscription_platform.exchange_rates
+    vat_rates:
+      type: table_view
+      tables:
+        - table: mozdata.subscription_platform.vat_rates
     # Logical subscriptions
     logical_subscriptions:
       type: table_view


### PR DESCRIPTION
The associated BigQuery views were just added in https://github.com/mozilla/bigquery-etl/pull/7957 and https://github.com/mozilla/bigquery-etl/pull/7958, and this will allow them to be used in Looker.