### PR TITLE
fix: Don't try to install `software-properties-common` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN groupadd --gid ${USER_ID} ${GROUP_ID} && \
 
 # For grpc https://github.com/grpc/grpc/issues/24556#issuecomment-751797589
 RUN apt-get update -qqy && \
-    apt-get install -qqy build-essential git curl software-properties-common
+    apt-get install -qqy build-essential git curl
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null


### PR DESCRIPTION
The `build-container` CI jobs started failing this week with the error "_Unable to locate package software-properties-common_".

The `Dockerfile` was updated to install the `software-properties-common` package back in 2021 to facilitate installing the GitHub CLI (#52), and luckily it appears that installing `software-properties-common` is actually no longer necessary.