### PR TITLE
feat(DENG-9334): Delete unused Firefox desktop views & explores

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -56,6 +56,13 @@
       - installation
       - migration
       - topsites_impression
+- firefox_desktop:
+    views:
+      - deletion_request
+      - pseudo_main
+    explores:
+      - deletion_request
+      - pseudo_main
 - firefox_ios:
     views:
       - temp_bookmarks_sync


### PR DESCRIPTION
This adds the 2 `firefox_desktop` views/explores to the disallow list:
- deletion_request
- pseudo_main