### PR TITLE
feat(DENG-9334): Remove some explores/views from Firefox Desktop namespace

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -63,12 +63,14 @@
       - pageload_base_domain
       - pseudo_main
       - profiles
+      - quick_suggest_deletion_request
     explores:
       - deletion_request
       - pageload_domain
       - pageload_base_domain
       - pseudo_main
       - profiles
+      - quick_suggest_deletion_request
 - firefox_ios:
     views:
       - temp_bookmarks_sync

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -67,6 +67,7 @@
       - quick_suggest_deletion_request
       - serp_categorization
       - third_party_modules
+      - top_sites
     explores:
       - deletion_request
       - events_stream_table
@@ -77,6 +78,7 @@
       - quick_suggest_deletion_request
       - serp_categorization
       - third_party_modules
+      - top_sites
 - firefox_ios:
     views:
       - temp_bookmarks_sync

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -66,6 +66,7 @@
       - profiles
       - quick_suggest_deletion_request
       - serp_categorization
+      - third_party_modules
     explores:
       - deletion_request
       - events_stream_table
@@ -75,6 +76,7 @@
       - profiles
       - quick_suggest_deletion_request
       - serp_categorization
+      - third_party_modules
 - firefox_ios:
     views:
       - temp_bookmarks_sync

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -64,6 +64,7 @@
       - pseudo_main
       - profiles
       - quick_suggest_deletion_request
+      - serp_categorization
     explores:
       - deletion_request
       - pageload_domain
@@ -71,6 +72,7 @@
       - pseudo_main
       - profiles
       - quick_suggest_deletion_request
+      - serp_categorization
 - firefox_ios:
     views:
       - temp_bookmarks_sync

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -59,6 +59,7 @@
 - firefox_desktop:
     views:
       - deletion_request
+      - events_stream_table
       - pageload_domain
       - pageload_base_domain
       - pseudo_main
@@ -67,6 +68,7 @@
       - serp_categorization
     explores:
       - deletion_request
+      - events_stream_table
       - pageload_domain
       - pageload_base_domain
       - pseudo_main

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -59,10 +59,16 @@
 - firefox_desktop:
     views:
       - deletion_request
+      - pageload_domain
+      - pageload_base_domain
       - pseudo_main
+      - profiles
     explores:
       - deletion_request
+      - pageload_domain
+      - pageload_base_domain
       - pseudo_main
+      - profiles
 - firefox_ios:
     views:
       - temp_bookmarks_sync


### PR DESCRIPTION
This PR removes the following unused views/explores from the `firefox_desktop` namespace: 
- pageload_domain
- pageload_base_domain
- events_stream_table
- profiles
- quick_suggestion_deletion_request
- serp_categorization
- third_party_modules
- top_sites