### PR TITLE
feat(DENG-9334): Remove un-used views/explores from Firefox Desktop namespace

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -60,6 +60,7 @@
     views:
       - deletion_request
       - events_stream_table
+      - nimbus_targeting_context
       - pageload_domain
       - pageload_base_domain
       - pseudo_main
@@ -72,6 +73,7 @@
     explores:
       - deletion_request
       - events_stream_table
+      - nimbus_targeting_context
       - pageload_domain
       - pageload_base_domain
       - pseudo_main

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -68,6 +68,7 @@
       - serp_categorization
       - third_party_modules
       - top_sites
+      - update
     explores:
       - deletion_request
       - events_stream_table
@@ -79,6 +80,7 @@
       - serp_categorization
       - third_party_modules
       - top_sites
+      - update
 - firefox_ios:
     views:
       - temp_bookmarks_sync

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -61,6 +61,7 @@
       - deletion_request
       - events_stream_table
       - nimbus_targeting_context
+      - onboarding_opt_out
       - pageload_domain
       - pageload_base_domain
       - pseudo_main
@@ -74,6 +75,7 @@
       - deletion_request
       - events_stream_table
       - nimbus_targeting_context
+      - onboarding_opt_out
       - pageload_domain
       - pageload_base_domain
       - pseudo_main


### PR DESCRIPTION
Remove the following unused views from the `firefox_desktop` namespace:
- nimbus_targeting_context
- onboarding_opt_out
- update