### PR TITLE
feat(DENG-9334): Add funnel_analysis to namespace dissallow list

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -60,6 +60,7 @@
     views:
       - deletion_request
       - events_stream_table
+      - funnel_analysis
       - nimbus_targeting_context
       - onboarding_opt_out
       - pageload_domain
@@ -74,6 +75,7 @@
     explores:
       - deletion_request
       - events_stream_table
+      - funnel_analysis
       - nimbus_targeting_context
       - onboarding_opt_out
       - pageload_domain


### PR DESCRIPTION
This PR adds the `funnel analysis` view & explore to the firefox_desktop namespace disallow list.