### PR TITLE
feat(DENG-9334): Add some removed explores back 

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -60,9 +60,6 @@
     views:
       - deletion_request
       - events_stream_table
-      - funnel_analysis
-      - growth_accounting
-      - newtab_content
       - nimbus_targeting_context
       - onboarding_opt_out
       - pageload_domain
@@ -79,9 +76,6 @@
     explores:
       - deletion_request
       - events_stream_table
-      - funnel_analysis
-      - growth_accounting
-      - newtab_content
       - nimbus_targeting_context
       - onboarding_opt_out
       - pageload_domain


### PR DESCRIPTION
This PR adds back the following explores:

- newtab_content
- funnel_analysis
- growth_accounting