### PR TITLE
feat(DENG-9334): Add unused views/explores to firefox_desktop namespace disallow list

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -72,6 +72,7 @@
       - profiles
       - quick_suggest_deletion_request
       - serp_categorization
+      - sync
       - third_party_modules
       - top_sites
       - update
@@ -91,6 +92,7 @@
       - profiles
       - quick_suggest_deletion_request
       - serp_categorization
+      - sync
       - third_party_modules
       - top_sites
       - update

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -76,6 +76,7 @@
       - third_party_modules
       - top_sites
       - update
+      - urlbar_keyword_exposure
       - urlbar_potential_exposure
     explores:
       - deletion_request
@@ -96,6 +97,7 @@
       - third_party_modules
       - top_sites
       - update
+      - urlbar_keyword_exposure
       - urlbar_potential_exposure
 - firefox_ios:
     views:


### PR DESCRIPTION
This PR adds the following unused views/explores to firefox_desktop namespace disallow list:
- sync
- urlbar_keyword_exposure