### PR TITLE
Update Looker views to use ad_metrics

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -792,11 +792,11 @@ ads:
     consolidated_ad_metrics_daily_pt:
       type: table_view
       tables:
-        - table: mozdata.ads.consolidated_ad_metrics_daily_pt
+        - table: mozdata.ads.ad_metrics_daily_pt
     consolidated_ad_metrics_hourly:
       type: table_view
       tables:
-        - table: mozdata.ads.consolidated_ad_metrics_hourly
+        - table: mozdata.ads.ad_metrics
     tiles_addressable_inventory_hourly:
       type: table_view
       tables:


### PR DESCRIPTION
Implements [AD-1040](https://mozilla-hub.atlassian.net/browse/AD-1040).
Enables deprecation of older views.

Keeping the view names for compatibility and less impact on users.