### PR TITLE
feat(DENG-9334): Add user_characteristics to namespace disallow list

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -79,6 +79,7 @@
       - update
       - urlbar_keyword_exposure
       - urlbar_potential_exposure
+      - user_characteristics
     explores:
       - deletion_request
       - events_stream_table
@@ -101,6 +102,7 @@
       - update
       - urlbar_keyword_exposure
       - urlbar_potential_exposure
+      - user_characteristics
 - firefox_ios:
     views:
       - temp_bookmarks_sync


### PR DESCRIPTION
This PR removes `user_characteristics` view & explore from Firefox Desktop namespace since it's unused.