### PR TITLE
Switch ga4_sessions to reference view, not table

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1520,7 +1520,7 @@ websites:
     ga4_sessions:
       type: table_view
       tables:
-        - table: moz-fx-data-shared-prod.mozilla_org.ga_sessions_v2
+        - table: moz-fx-data-shared-prod.mozilla_org.ga_sessions
     firefox_com_ga4_sessions:
       type: table_view
       tables:


### PR DESCRIPTION
This PR updates the Looker view `ga4_sessions` to point to the view `moz-fx-data-shared-prod.mozilla_org.ga_sessions` , instead of the view `moz-fx-data-shared-prod.mozilla_org.ga_sessions_v2`