### PR TITLE
feat(DENG-9337): Remove unused MDN Yari explores & views

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -137,12 +137,10 @@
     views:
       - action
       - deletion_request
-      - event_counts
       - events_stream_table
     explores:
       - action
       - deletion_request
-      - event_counts
       - events_stream_table
 - monitor_frontend:
     views:


### PR DESCRIPTION
This PR adds the following views & explores in MDN Yari to the disallow list, since they are un-used.

- action
- deletion_request
- events_stream_table

Related JIRA ticket: 
- [DENG-9337](https://mozilla-hub.atlassian.net/browse/DENG-9337)