### PR TITLE
feat(DENG-9337): Add event_counts explore for MDN Yari to disallow list

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -141,6 +141,7 @@
     explores:
       - action
       - deletion_request
+      - event_counts
       - events_stream_table
 - monitor_frontend:
     views:


### PR DESCRIPTION
This PR adds the explore `event_counts` to the disallow list for the `mdn_yari` namespace.