### PR TITLE
feat(DENG-9337): Exclude event_counts view from mdn_yari since unused

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -137,6 +137,7 @@
     views:
       - action
       - deletion_request
+      - event_counts
       - events_stream_table
     explores:
       - action


### PR DESCRIPTION
For the `mdn_yari` namespace, add "event_counts" view to the disallow list since it hasn't been used in over 90 days.