### PR TITLE
feat: swap newtab_items_daily_v1 with new view newtab_content_items_daily_combined_v1

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1104,7 +1104,7 @@ firefox_desktop:
     newtab_items_daily:
       type: table_view
       tables:
-        - table: moz-fx-data-shared-prod.firefox_desktop_derived.newtab_items_daily_v1
+        - table: moz-fx-data-shared-prod.firefox_desktop_derived.newtab_content_items_daily_combined_v1
   explores:
     client_counts:
       type: client_counts_explore


### PR DESCRIPTION
This swaps out the new view with the newtab-content ping data. The schema will be functionally the same with a couple of small changes and is only used in one explore.