### PR TITLE
fix: Remove reference to the `ios_app_campaign_stats` table, which has been deleted

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1820,10 +1820,6 @@ growth:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.google_ads.android_app_campaign_stats
-    ios_app_campaign_stats:
-      type: table_view
-      tables:
-        - table: moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1
     rolling_28_day_dau:
       type: table_view
       tables:


### PR DESCRIPTION
See https://github.com/mozilla/bigquery-etl/pull/8164.

This is currently [causing LookML generation to fail](https://workflow.telemetry.mozilla.org/dags/looker/grid?dag_run_id=manual__2025-09-26T20%3A17%3A44.899677%2B00%3A00&task_id=lookml_generator_staging&tab=logs).