### PR TITLE
Change name of explore and location of table (affects no other looks)

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1120,10 +1120,10 @@ firefox_desktop:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.analysis.ctroy_prototype_step_4_one_month_with_fx_reasons
-    prototype_events_per_feature:
+    prototype_feature_events:
       type: table_view
       tables:
-        - table: moz-fx-data-shared-prod.analysis.ctroy_prototype_one_month_event_proportions
+        - table: moz-fx-data-shared-prod.analysis.ctroy_prototype_one_month_feature_events
   explores:
     client_counts:
       type: client_counts_explore
@@ -1160,10 +1160,10 @@ firefox_desktop:
       type: table_explore
       views:
         base_view: prototype_features_and_firefox_use_cases
-    prototype_events_per_feature:
+    prototype_feature_events:
       type: table_explore
       views:
-        base_view: prototype_events_per_feature
+        base_view: prototype_feature_events
 monitoring:
   glean_app: false
   owners:


### PR DESCRIPTION
I updated the schema of this table and triggered the job to deploy lookml-generator. The next day, the schema had not updated, and all queries to the explore in looker were failing due to the Looker schema differing from the schema of the underlying table. 

<img width="1245" height="589" alt="Screenshot 2025-10-29 at 10 57 13 AM" src="https://github.com/user-attachments/assets/398d3074-b589-4db8-a4ce-b96d2aa7b668" />

This change attempts to force a schema update, or at least the deployment of a new look matching the table's current schema. 

