### PR TITLE
fix(CI): Pin pip to v25.2 until jazzband/pip-tools#2252 is fixed

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -17,9 +17,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
+          # Temporarily pin pip until https://github.com/jazzband/pip-tools/issues/2252 is fixed.
+          pip-version: '25.2'
       - name: Verify requirements.txt dependencies
         run: |
           pip install pip-tools --constraint requirements.in
@@ -37,9 +39,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
+          # Temporarily pin pip until https://github.com/jazzband/pip-tools/issues/2252 is fixed.
+          pip-version: '25.2'
           cache: 'pip'
       - name: Install dependencies
         run: |
@@ -79,9 +83,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
+          # Temporarily pin pip until https://github.com/jazzband/pip-tools/issues/2252 is fixed.
+          pip-version: '25.2'
           cache: 'pip'
       - name: Install dependencies
         run: |
@@ -114,9 +120,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
+          # Temporarily pin pip until https://github.com/jazzband/pip-tools/issues/2252 is fixed.
+          pip-version: '25.2'
           cache: 'pip'
       - name: Install dependencies
         run: |


### PR DESCRIPTION
`pip-tools` 7.51. is incompatible with `pip` 25.3 (https://github.com/jazzband/pip-tools/issues/2252).