### PR TITLE
fix: Remove timeframes from dimension groups if the resulting dimension would conflict with an existing dimension

### DIFF
--- a/generator/views/glean_ping_view.py
+++ b/generator/views/glean_ping_view.py
@@ -340,13 +340,18 @@ class GleanPingView(PingView):
             # will add a _{type} suffix to its individual dimension name.
             lookml["name"] = re.sub("_(date|time(stamp)?)$", "", looker_name)
             lookml["timeframes"] = [
-                "raw",
-                "time",
-                "date",
-                "week",
-                "month",
-                "quarter",
-                "year",
+                timeframe
+                for timeframe in (
+                    "raw",
+                    "time",
+                    "date",
+                    "week",
+                    "month",
+                    "quarter",
+                    "year",
+                )
+                # Exclude timeframes where the resulting dimension would conflict with an existing dimension.
+                if f"{lookml['name']}_{timeframe}" not in sql_map
             ]
             # Dimension groups should not be nested (see issue #82).
             del lookml["group_label"]

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -434,6 +434,10 @@ class MockDryRunLookml(MockDryRun):
                     "name": "event",
                     "type": "STRING",
                 },
+                {
+                    "name": "event_year",
+                    "type": "INTEGER",
+                },
             ]
         if table_ref == "mozdata.fail.duplicate_client":
             return [
@@ -1994,7 +1998,6 @@ def test_duplicate_dimension_event(runner, glean_apps, tmp_path):
                                 "week",
                                 "month",
                                 "quarter",
-                                "year",
                             ],
                             "type": "time",
                         },
@@ -2019,7 +2022,13 @@ def test_duplicate_dimension_event(runner, glean_apps, tmp_path):
                             "sql": "${TABLE}.event",
                             "suggest_persist_for": "24 hours",
                             "type": "string",
-                        }
+                        },
+                        {
+                            "name": "event_year",
+                            "sql": "${TABLE}.event_year",
+                            "suggest_persist_for": "24 hours",
+                            "type": "number",
+                        },
                     ],
                     "name": "events_stream",
                     "sql_table_name": "`mozdata.pass.duplicate_event_dimension`",


### PR DESCRIPTION
To resolve the following `looker-hub` LookML validation errors:
```
There is already a "field" named "active_users_table.first_seen_year"
3 occurrences
fenix/views/active_users_table:490
firefox_ios/views/active_users_table:490
focus_android/views/active_users_table:490

There is already a "field" named "composite_active_users_table.first_seen_year"
4 occurrences
fenix/views/composite_active_users_table:147
firefox_desktop/views/composite_active_users_table:153
firefox_ios/views/composite_active_users_table:147
focus_android/views/composite_active_users_table:147

There is already a "field" named "usage_reporting_active_users_table.first_seen_year"
4 occurrences
fenix/views/usage_reporting_active_users_table:204
firefox_desktop/views/usage_reporting_active_users_table:216
firefox_ios/views/usage_reporting_active_users_table:204
focus_android/views/usage_reporting_active_users_table:204

There is already a "field" named "baseline_active_users_table.first_seen_year"
firefox_desktop/views/baseline_active_users_table:545
```