### PR TITLE
fix: Correct `always_filter` syntax in `events_stream` explores (DENG-9548)

### DIFF
--- a/generator/explores/events_stream_explore.py
+++ b/generator/explores/events_stream_explore.py
@@ -36,7 +36,9 @@ class EventsStreamExplore(Explore):
             "name": self.name,
             "view_name": self.views["base_view"],
             "joins": self.get_unnested_fields_joins_lookml(),
-            "always_filter": self.get_required_filters("base_view"),
+            "always_filter": {
+                "filters": self.get_required_filters("base_view"),
+            },
             "queries": [
                 {
                     "name": "recent_event_counts",


### PR DESCRIPTION
## [DENG-9548](https://mozilla-hub.atlassian.net/browse/DENG-9548): Generate purpose-built events stream Looker explores

Fixup for https://github.com/mozilla/lookml-generator/pull/1356.