### PR TITLE
fix: Fill in missing `events_stream.event_id` values with generated UUIDs (DENG-9800)

### DIFF
--- a/generator/views/events_stream_view.py
+++ b/generator/views/events_stream_view.py
@@ -65,6 +65,8 @@ class EventsStreamView(View):
         )
         for dimension in dimensions:
             if dimension["name"] == "event_id":
+                # `event_id` columns were added in https://github.com/mozilla/bigquery-etl/pull/8596.
+                dimension["sql"] = "COALESCE(${TABLE}.event_id, GENERATE_UUID())"
                 dimension["primary_key"] = "yes"
 
         measures = self.get_measures(dimensions)


### PR DESCRIPTION
`events_stream.event_id` columns are being added in https://github.com/mozilla/bigquery-etl/pull/8596 ([DENG-9800](https://mozilla-hub.atlassian.net/browse/DENG-9800)), but historical `events_stream` records won't have `event_id` values, so this PR updates the `event_id` dimensions to dynamically fill in values for those as needed so Looker can accurately aggregate when doing one-to-many joins.