### PR TITLE
added monthly content forecast

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -963,6 +963,10 @@ ads:
       type: table_explore
       views:
         base_view: equativ_line_item_delivery
+    forecast_content_monthly:
+      type: table_explore
+      views: 
+        base_view: forecast_content_monthly
 ads_monitoring:
   glean_app: false
   connection: bigquery-oauth


### PR DESCRIPTION
Some of the field names are changing so they it is clearer what actual and forecast values should be compared and where they come from:
forecast_sponsored_impressions ->forecast_native_glean_sponsored_impressions_sum
actual_native_glean_sponsored_content_impressions -> actual_native_glean_sponsored_impressions_sum