### PR TITLE
Revert "Add subscription_platform_frontend to disallowlist"

### DIFF
--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -44,7 +44,6 @@
 - klar_ios
 - focus_android
 - klar_android
-- subscription_platform_frontend
 - fenix:
     views:
       - bookmarks_sync


### PR DESCRIPTION
Reverts mozilla/lookml-generator#1422, as the SubPlat frontend is now sending Glean telemetry and the SubPlat team wants to analyze it (CC @xlisachan).