### PR TITLE
feat: add ads_client_operations_and_errors_hourly view and explore

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1156,6 +1156,10 @@ ads:
           based_on_time: submission_month_date
           period: month
           value_to_date: "no"
+    ads_client_operations_and_errors_hourly:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1
   explores:
     campaigns_monthly:
       type: table_explore
@@ -1185,6 +1189,10 @@ ads:
       type: table_explore
       views:
         base_view: equativ_monthly_with_line_item
+    ads_client_operations_and_errors_hourly:
+      type: table_explore
+      views:
+        base_view: ads_client_operations_and_errors_hourly
 ads_monitoring:
   glean_app: false
   connection: bigquery-oauth


### PR DESCRIPTION
## Summary
- Add `ads_client_operations_and_errors_hourly` as a `table_view` and `table_explore` under the `ads` namespace in `custom-namespaces.yaml`
- Source table: `moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1`

## Test plan
- [ ] CI passes