### PR TITLE
Remove unused prototype feature configurations

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1611,18 +1611,6 @@ firefox_desktop:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.firefox_desktop.prototype_user_segmentation_tabgroups_v2
-    prototype_features_and_firefox_use_cases:
-      type: table_view
-      tables:
-        - table: moz-fx-data-shared-prod.analysis.ctroy_prototype_step_4_one_month_with_fx_reasons
-    prototype_feature_events:
-      type: table_view
-      tables:
-        - table: moz-fx-data-shared-prod.analysis.ctroy_prototype_one_month_feature_events
-    prototype_cross_feature_usage:
-      type: table_view
-      tables:
-        - table: moz-fx-data-shared-prod.analysis.ctroy_prototype_cross_feature_usage
   explores:
     client_counts:
       type: client_counts_explore
@@ -1655,18 +1643,6 @@ firefox_desktop:
       type: table_explore
       views:
         base_view: prototype_feature_segmentation
-    prototype_features_and_firefox_use_cases:
-      type: table_explore
-      views:
-        base_view: prototype_features_and_firefox_use_cases
-    prototype_feature_events:
-      type: table_explore
-      views:
-        base_view: prototype_feature_events
-    prototype_cross_feature_usage:
-      type: table_explore
-      views:
-        base_view: prototype_cross_feature_usage
 monitoring:
   glean_app: false
   owners:


### PR DESCRIPTION
I believe this workstream has been discontinued. We should be able to remove these from Looker as the analysis tables have expired.

This will unblock Looker Airflow deploys.