### PR TITLE
Add skip list for deprecated apps

### DIFF
--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -31,6 +31,7 @@ PROBE_INFO_BASE_URI = "https://probeinfo.telemetry.mozilla.org"
 DEFAULT_SPOKE = "looker-spoke-default"
 OPMON_DATASET = "operational_monitoring"
 PROD_PROJECT = "moz-fx-data-shared-prod"
+SKIP_DEPRECATED = ["mozilla_vpn"]
 
 
 def _normalize_slug(name):
@@ -233,6 +234,8 @@ def _get_glean_apps(
             }
             for channel in variants
             if not channel.get("deprecated")
+            or channel.get("app_name")
+            not in SKIP_DEPRECATED  # TODO handling for deprecated apps
         ]
 
         # If all channels are deprecated, don't include this app


### PR DESCRIPTION
`mozilla_vpn` got deprecated recently which resulted in lots of lookml errors. Skipping deprecation until we figure out how to handle deprecated apps