### PR TITLE
[DENG-11122] Don't skip generation of deprecated apps

### DIFF
--- a/custom-namespaces.yaml
+++ b/custom-namespaces.yaml
@@ -1879,6 +1879,10 @@ monitoring:
       type: table_view
       tables:
         - table: moz-fx-data-shared-prod.monitoring_derived.looker_user_reported_issues_v1
+    probe_scraper_applications:
+      type: table_view
+      tables:
+        - table: moz-fx-data-shared-prod.monitoring_derived.probe_scraper_applications_v1
   explores:
     payload_bytes_error_all:
       type: ping_explore
@@ -1940,6 +1944,10 @@ monitoring:
       type: table_explore
       views:
         base_view: looker_user_reported_issues
+    probe_scraper_applications:
+      type: table_explore
+      views:
+        base_view: probe_scraper_applications
 
 reference:
   glean_app: false

--- a/generator/namespaces.py
+++ b/generator/namespaces.py
@@ -31,7 +31,6 @@ PROBE_INFO_BASE_URI = "https://probeinfo.telemetry.mozilla.org"
 DEFAULT_SPOKE = "looker-spoke-default"
 OPMON_DATASET = "operational_monitoring"
 PROD_PROJECT = "moz-fx-data-shared-prod"
-SKIP_DEPRECATED = ["mozilla-vpn"]
 
 
 def _normalize_slug(name):
@@ -233,23 +232,18 @@ def _get_glean_apps(
                 ),
             }
             for channel in variants
-            if not channel.get("deprecated")
-            or channel.get("app_name")
-            not in SKIP_DEPRECATED  # TODO handling for deprecated apps
         ]
 
-        # If all channels are deprecated, don't include this app
-        if channels:
-            apps.append(
-                {
-                    "name": app_name,
-                    "pretty_name": canonical_app_name,
-                    "channels": channels,
-                    "owners": emails,
-                    "glean_app": True,
-                    "v1_name": v1_name,
-                }
-            )
+        apps.append(
+            {
+                "name": app_name,
+                "pretty_name": canonical_app_name,
+                "channels": channels,
+                "owners": emails,
+                "glean_app": True,
+                "v1_name": v1_name,
+            }
+        )
 
     return apps
 

--- a/namespaces-disallowlist.yaml
+++ b/namespaces-disallowlist.yaml
@@ -1,10 +1,12 @@
 ---
 - burnham
+- bergamot
 - experimenter_backend
 - firefox_echo_show
 - firefox_fire_tv
 - firefox_reality
 - firefox_reality_pc
+- firefox_translations
 - lockwise_android
 - lockwise_ios
 - mlhackweek_search


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-11122 

We had a recent case where deprecating `mozilla_vpn` resulted in various artifacts not being generated anymore, which broke lookml validation and existing . See https://github.com/mozilla/lookml-generator/pull/1438 

This PR removes the logic that skips generation for deprecated apps. Instead these apps need to leverage the `disallow-namespaces.yaml` after going through the deprecation process. 

Depends on https://github.com/mozilla/bigquery-etl/pull/9374